### PR TITLE
[Feat] 프롬프트 TIP & 마이페이지 메시지함 반응형 UI

### DIFF
--- a/src/pages/MyPage/MyMessageDetailPage.tsx
+++ b/src/pages/MyPage/MyMessageDetailPage.tsx
@@ -52,41 +52,74 @@ const MyMessageDetailPage = ({ type }: MyMessageDetailPageProps) => {
   };
 
   return (
-    <div className="min-h-[calc(100vh-24px)] bg-background flex justify-center items-center ">
-      {/**min-h-[calc(100vh-24px)] : 추후 min-h 부분은 navbar에 따라서 수정 필요 */}
-      <div className="w-[994px] h-[868px] bg-white rounded-t-[16px] rounded-b-[16px]">
-        <div className="w-[994px] h-[105px] pt-[35px] pl-[20px] pr-[10px]">
-          <div className="w-[187px] h-[50px] flex items-center gap-[10px] p-[10px]" onClick={handleNavigate}>
-            <LuChevronLeft size={24} />
-            <span className="text-text-on-white font-bold text-[24px] ">메시지함</span>
-          </div>
-        </div>
+    <>
+      <div className="hidden lg:block">
+        {' '}
+        <div className="min-h-[calc(100vh-24px)] bg-background flex justify-center items-center ">
+          {/**min-h-[calc(100vh-24px)] : 추후 min-h 부분은 navbar에 따라서 수정 필요 */}
+          <div className="w-[994px] h-[868px] bg-white rounded-t-[16px] rounded-b-[16px]">
+            <div className="w-[994px] h-[105px] pt-[35px] pl-[20px] pr-[10px]">
+              <div className="w-[187px] h-[50px] flex items-center gap-[10px] p-[10px]" onClick={handleNavigate}>
+                <LuChevronLeft size={24} />
+                <span className="text-text-on-white font-bold text-[24px] ">메시지함</span>
+              </div>
+            </div>
 
-        <div className="w-[994px] h-[153px] flex flex-col justify-center border-b-[1px] border-white-stroke px-[65px]">
-          <h1 className="font-bold text-[32px] text-text-on-white pt-[30px]">{message.title}</h1>
-          <div className="w-[404px]  flex justify-between gap-[10px] items-center">
-            <p className="w-[197px] font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">
-              {message.create_at}
-            </p>
-            <p className="w-[197px] font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">
-              보낸 사람 : {message.sender_id}
-            </p>
-          </div>
-        </div>
+            <div className="w-[994px] h-[153px] flex flex-col justify-center border-b-[1px] border-white-stroke px-[65px]">
+              <h1 className="font-bold text-[32px] text-text-on-white pt-[30px]">{message.title}</h1>
+              <div className="w-[404px]  flex justify-between gap-[10px] items-center">
+                <p className="w-[197px] font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">
+                  {message.create_at}
+                </p>
+                <p className="w-[197px] font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">
+                  보낸 사람 : {message.sender_id}
+                </p>
+              </div>
+            </div>
 
-        <div className="w-[994px] h-[485px] flex justify-center overflow-y-auto prose prose-neutral max-w-none text-base">
-          <div className="w-[864px] border-b-[1px] border-white-stroke font-medium text-[20px] text-text-on-white py-[30px]">
-            {message.body}
-          </div>
-          {/**추후 다시 markdown 적용해보기... */}
-        </div>
+            <div className="w-[994px] h-[485px] flex justify-center overflow-y-auto prose prose-neutral max-w-none text-base">
+              <div className="w-[864px] border-b-[1px] border-white-stroke font-medium text-[20px] text-text-on-white py-[30px]">
+                {message.body}
+              </div>
+              {/**추후 다시 markdown 적용해보기... */}
+            </div>
 
-        {/**하단 */}
-        <div className="w-[994px] h-[125px]  flex justify-center">
-          <div className="w-[864px] h-[45px] flex justify-between mt-[33px] mb-[47px]"></div>
+            {/**하단 */}
+            <div className="w-[994px] h-[125px]  flex justify-center">
+              <div className="w-[864px] h-[45px] flex justify-between mt-[33px] mb-[47px]"></div>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+
+      {/*모바일 화면 */}
+      <div className="lg:hidden block">
+        <div className="relative w-full h-12  flex items-center">
+          <button className="ml-[12px] flex items-center cursor-pointer" onClick={handleNavigate}>
+            <LuChevronLeft size={24} />
+          </button>
+          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold text-xl tracking-wide">
+            <p className="text-[16px] text-black font-medium"> 메시지함</p>
+          </span>
+        </div>
+        <div className=" flex justify-center items-center mt-[20px]">
+          <div className="w-full max-w-[280px] h-full min-h-[420px] bg-white">
+            {/*상단 */}
+            <div className="w-full max-w-[280px] h-full max-h-[80px] border-b-[0.5px] border-white-stroke px-[20px]">
+              <h1 className="font-medium text-[12px] text-text-on-white mt-[20px]">{message.title}</h1>
+              <div className="h-[13px] flex justify-start items-center mt-[12px] mb-[23px] gap-[24px]">
+                <p className="font-normal text-[8px] text-text-on-background ">{message.create_at}</p>
+                <p className="font-medium text-[10px] text-text-on-white">보낸 사람 : {message.sender_id}</p>
+              </div>
+            </div>
+            {/*본문 */}
+            <div className="w-full max-w-[280px] h-full min-h-[275px] border-white-stroke p-[20px] ">
+              <div className="text-[10px] text-text-on-white font-medium">{message.body}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/MyPage/MyMessagePage.tsx
+++ b/src/pages/MyPage/MyMessagePage.tsx
@@ -181,7 +181,7 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
       {/*모바일 화면 */}
       <div className="lg:hidden block">
         <div>
-          <p className="ml-[20px] mt-[12px] text-primary-hover text-[20px] font-bold">프롬프트 TIP</p>
+          <p className="ml-[20px] mt-[12px] text-primary-hover text-[20px] font-bold">메시지함</p>
         </div>
       </div>
       <div className="relative inline-block w-full max-w-[108px] h-[31px] mt-[20px] ml-[20px]" ref={ref}>

--- a/src/pages/MyPage/MyMessagePage.tsx
+++ b/src/pages/MyPage/MyMessagePage.tsx
@@ -5,10 +5,12 @@
  * @author 김진효
  * **/
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { MessageTableList, MessagePagination } from './components/MessagePagination';
-import { NotificationTableList, NotificationPagination } from './components/NotificationPagination';
+import { MessageTableList, MessagePagination, MobileMessage } from './components/MessagePagination';
+import { NotificationTableList, NotificationPagination, MobileNotification } from './components/NotificationPagination';
+
+import { LuChevronDown } from 'react-icons/lu';
 
 interface MyMessagePageProps {
   type: 'message' | 'notification';
@@ -117,61 +119,132 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
     setMessages((prev) => prev.map((msg) => (msg.id === id ? { ...msg, is_read: true } : msg)));
   };
 
+  //모바일 화면
+  const [openType, setOpenType] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
   return (
-    <div className="">
-      <div className="min-w-[1440px] min-h-[1024px] w-full h-full bg-background">
-        <div className="flex justify-between items-center">
-          <div className=" w-[360px] h-[60px] mt-[92px] ml-[102px]">
-            <button
-              onClick={() => handleTypeChange('message')}
-              className={`${
-                type === 'message'
-                  ? 'text-primary-hover font-bold text-[32px] border-r-[2px] border-r-primary-hover'
-                  : 'text-text-on-background font-bold text-[24px]'
-              } h-[60px] pt-[10px] pb-[10px] pr-[40px]  -translate-y-[10px]`}>
-              <p className="h-[40px]  -translate-y-[6px]">메시지함</p>
-            </button>
+    <>
+      <div className="hidden lg:block">
+        <div className="min-w-[1440px] min-h-[1024px] w-full h-full bg-background">
+          <div className="flex justify-between items-center">
+            <div className=" w-[360px] h-[60px] mt-[92px] ml-[102px]">
+              <button
+                onClick={() => handleTypeChange('message')}
+                className={`${
+                  type === 'message'
+                    ? 'text-primary-hover font-bold text-[32px] border-r-[2px] border-r-primary-hover'
+                    : 'text-text-on-background font-bold text-[24px]'
+                } h-[60px] pt-[10px] pb-[10px] pr-[40px]  -translate-y-[10px]`}>
+                <p className="h-[40px]  -translate-y-[6px]">메시지함</p>
+              </button>
 
-            <button
-              onClick={() => handleTypeChange('notification')}
-              className={`${
-                type === 'notification'
-                  ? 'text-primary-hover font-bold text-[32px] border-l-[2px] border-l-primary-hover'
-                  : 'text-text-on-background font-bold text-[24px] '
-              } h-[60px] pt-[10px] pb-[10px] pl-[40px]  -translate-y-[10px]`}>
-              <p className="h-[40px] -translate-y-[6px]">알림</p>
-            </button>
+              <button
+                onClick={() => handleTypeChange('notification')}
+                className={`${
+                  type === 'notification'
+                    ? 'text-primary-hover font-bold text-[32px] border-l-[2px] border-l-primary-hover'
+                    : 'text-text-on-background font-bold text-[24px] '
+                } h-[60px] pt-[10px] pb-[10px] pl-[40px]  -translate-y-[10px]`}>
+                <p className="h-[40px] -translate-y-[6px]">알림</p>
+              </button>
+            </div>
+          </div>
+
+          <div className="flex flex-col justify-center items-center">
+            {type === 'message' ? (
+              <>
+                <MessageTableList
+                  data={pageMessageData}
+                  onRowClick={handleRowClick}
+                  onDelete={handleDelete}
+                  onRead={handleRead}
+                />
+                <MessagePagination
+                  currentPage={currentPage}
+                  totalPages={TOTAL_MESSAGE_PAGES}
+                  onPageChange={handlePageChange}
+                />
+              </>
+            ) : (
+              <>
+                <NotificationTableList data={pageNotificationData} />
+                <NotificationPagination
+                  currentPage={currentPage}
+                  totalPages={TOTAL_Notification_PAGES}
+                  onPageChange={handlePageChange}
+                />
+              </>
+            )}
           </div>
         </div>
-
-        <div className="flex flex-col justify-center items-center">
-          {type === 'message' ? (
-            <>
-              <MessageTableList
-                data={pageMessageData}
-                onRowClick={handleRowClick}
-                onDelete={handleDelete}
-                onRead={handleRead}
-              />
-              <MessagePagination
-                currentPage={currentPage}
-                totalPages={TOTAL_MESSAGE_PAGES}
-                onPageChange={handlePageChange}
-              />
-            </>
-          ) : (
-            <>
-              <NotificationTableList data={pageNotificationData} />
-              <NotificationPagination
-                currentPage={currentPage}
-                totalPages={TOTAL_Notification_PAGES}
-                onPageChange={handlePageChange}
-              />
-            </>
-          )}
+      </div>
+      {/*모바일 화면 */}
+      <div className="lg:hidden block">
+        <div>
+          <p className="ml-[20px] mt-[12px] text-primary-hover text-[20px] font-bold">프롬프트 TIP</p>
         </div>
       </div>
-    </div>
+      <div className="relative inline-block w-full max-w-[108px] h-[31px] mt-[20px] ml-[20px]" ref={ref}>
+        <button
+          type="button"
+          className="flex items-center justify-center gap-[8px] w-full px-[12px] py-[8px] rounded-[8px] bg-white"
+          style={{ boxShadow: '0px 1px 3px 0px rgba(0,0,0,0.08)' }}
+          onClick={() => setOpenType((prev) => !prev)}>
+          <span className="text-[12px] text-text-on-white font-medium">
+            {type === 'message' ? '메시지함' : '알림함'}
+          </span>
+          <LuChevronDown size={10} />
+        </button>
+        {/*드롭다운 */}
+        {openType && (
+          <ul
+            className="absolute left-0 z-10 w-[111px] h-[66px] mt-[6px] flex flex-col justify-center items-center
+               bg-white border-[0.5px] border-white-stroke rounded-[8px]"
+            style={{ boxShadow: '0px 1px 3px 0px rgba(0,0,0,0.08)' }}>
+            <li
+              className="w-[87px] h-[27px] flex justify-center items-center border-b-[0.5px] border-white-stroke"
+              onClick={() => {
+                navigate(`/mypage/message/message`);
+
+                setOpenType(false);
+              }}>
+              <p
+                className={`text-[12px] font-normal ${type === 'message' ? 'text-text-on-white' : 'text-text-on-background'}`}>
+                메시지함
+              </p>
+            </li>
+            <li
+              className="w-[87px] h-[27px] flex justify-center items-center "
+              onClick={() => {
+                navigate(`/mypage/message/notification`);
+                setOpenType(false);
+              }}>
+              <p
+                className={`text-[12px] font-normal ${type === 'notification' ? 'text-text-on-white' : 'text-text-on-background'}`}>
+                알림함
+              </p>
+            </li>
+          </ul>
+        )}
+      </div>
+
+      <div className="flex justify-center">
+        {type === 'message' ? (
+          <>
+            <MobileMessage
+              data={pageMessageData}
+              onRowClick={handleRowClick}
+              onDelete={handleDelete}
+              onRead={handleRead}
+            />
+          </>
+        ) : (
+          <>
+            <MobileNotification data={pageNotificationData} />
+          </>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/pages/MyPage/components/MessagePagination.tsx
+++ b/src/pages/MyPage/components/MessagePagination.tsx
@@ -5,6 +5,8 @@ import notread from '../../../assets/icon-mail-notread.svg';
 import { GoKebabHorizontal } from 'react-icons/go';
 import { useEffect, useRef, useState } from 'react';
 
+import kebabMenu from '@/assets/icon-kebabMenu.svg';
+
 interface MessageList {
   id: number;
   title: string;
@@ -36,6 +38,7 @@ export const MessageTableList = ({
     if (openId !== null) document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [openId]);
+
   return (
     <table className="w-full max-w-[1236px] max-h-[592px] mt-[22px] mb-[73px] mx-[102px]">
       <thead>
@@ -44,7 +47,7 @@ export const MessageTableList = ({
       <tbody>
         {data.length === 0 ? (
           <tr>
-            <td colSpan={3} className="text-center py-4 text-gray-400">
+            <td colSpan={3} className="text-center py-4 text-text-on-background">
               아무 연락이 없네요...(귀뚜라미 소리)
             </td>
           </tr>
@@ -166,3 +169,107 @@ export function MessagePagination({
     </nav>
   );
 }
+
+// 모바일 화면
+export const MobileMessage = ({
+  data,
+  onRowClick,
+  onDelete,
+  onRead,
+}: {
+  data: MessageList[];
+  onRowClick: (id: number) => void;
+  onDelete: (id: number) => void;
+  onRead: (id: number) => void;
+}) => {
+  const [openId, setOpenId] = useState<number | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setOpenId(null);
+      }
+    }
+    if (openId !== null) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [openId]);
+
+  return (
+    <div className="w-full max-w-[280px] my-[12px] cursor-pointer flex flex-col justify-center">
+      {data.length === 0 ? (
+        <div>
+          <div className="text-center py-4 text-text-on-background">아무 메시지가 없습니다.</div>
+        </div>
+      ) : (
+        data.map((message) => (
+          <div
+            key={message.id}
+            className="w-full max-w-[280px] h-[81px] flex flex-col justify-center border-b-[1px] border-white-stroke bg-white ">
+            <div className="flex justify-center">
+              <div className="flex justify-between w-full max-w-[256px]">
+                <p className="text-[8px] text-text-on-background font-normal">{message.create_at}</p>
+                <div className="relative">
+                  <button
+                    onClick={() => setOpenId(openId === message.id ? null : message.id)}
+                    className={`flex items-center justify-center h-[16px] w-[16px] rounded-[50px] ${
+                      openId === message.id ? 'bg-secondary-pressed' : 'bg-transparent'
+                    }`}>
+                    <img className="w-[10px] h-[10px]" src={kebabMenu} alt="...버튼" />
+                  </button>
+                  {/*드롭다운 */}
+                  {openId === message.id && (
+                    <div
+                      className="absolute right-0 top-full mt-[11px] w-[91px] bg-white rounded-md shadow-lg z-10"
+                      ref={menuRef}>
+                      <button
+                        onClick={() => {
+                          onDelete(message.id);
+                          setOpenId(null);
+                        }}
+                        className="block w-full h-[36px] text-[16px] border-b-[1px] border-b-white-stroke text-text-on-background bg-secondary active:bg-secondary-pressed rounded-t-[4px]">
+                        삭제하기
+                      </button>
+                      <button
+                        onClick={() => {
+                          onRead(message.id);
+                          setOpenId(null);
+                        }}
+                        className="block w-full h-[36px] text-[16px] text-text-on-background bg-secondary active:bg-secondary-pressed rounded-b-[4px]">
+                        읽음표시
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-center">
+              <div
+                className="w-full max-w-[256px] h-[16px] flex justify-start items-center mt-[6px]"
+                onClick={() => onRowClick(message.id)}>
+                {message.is_read ? (
+                  <img className="w-[16px] h-[16px]" src={read} alt="읽음" />
+                ) : (
+                  <img className="w-[16px] h-[16px]" src={notread} alt="안 읽음" />
+                )}
+                <p
+                  className={`text-[12px] ${message.is_read ? 'text-text-on-background' : 'text-text-on-white'} font-medium ml-[6px]`}>
+                  {/*20자까지만 표시 */}
+                  {message.title.length > 20 ? message.title.slice(0, 20) + '...' : message.title}
+                </p>
+              </div>
+            </div>
+            <div className="flex justify-center">
+              <div className="w-full max-w-[256px] h-[16px] flex justify-start items-center mt-[6px]">
+                <p
+                  className={`text-[10px] ${message.is_read ? 'text-text-on-background' : 'text-text-on-white'} font-medium`}>
+                  {message.sender_id}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};

--- a/src/pages/MyPage/components/NotificationPagination.tsx
+++ b/src/pages/MyPage/components/NotificationPagination.tsx
@@ -1,6 +1,6 @@
 import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 
-import alarm from '../../../assets/icon-alarm-black.svg';
+import alarm from '@assets/icon-alarm-black.svg';
 
 interface NotificationList {
   id: number; //notification_id
@@ -10,14 +10,14 @@ interface NotificationList {
 // 페이지네이션 테이블
 export function NotificationTableList({ data }: { data: NotificationList[] }) {
   return (
-    <table className="w-[1236px] max-h-[592px] mt-[22px] mb-[73px] mx-[102px]">
+    <table className="w-full max-w-[1236px] max-h-[592px] mt-[22px] mb-[73px] mx-[102px]">
       <thead>
         <tr className="h-[72px] border-b-[1px] border-[var(--color-primary-hover)] bg-[var(--color-background)]"></tr>
       </thead>
       <tbody>
         {data.length === 0 ? (
           <tr>
-            <td colSpan={3} className="text-center py-4 text-gray-400">
+            <td colSpan={3} className="text-center py-4 text-text-on-background">
               아무 알림이 없네요...(귀뚜라미 소리)
             </td>
           </tr>
@@ -85,5 +85,38 @@ export function NotificationPagination({
         <LuChevronRight />
       </button>
     </nav>
+  );
+}
+
+// 모바일 화면
+export function MobileNotification({ data }: { data: NotificationList[] }) {
+  return (
+    <div className="w-full max-w-[280px] my-[12px] cursor-pointer flex flex-col justify-center">
+      {data.length === 0 ? (
+        <div>
+          <div className="text-center py-4 text-text-on-background">아무 알림이 없네요...(귀뚜라미 소리)</div>
+        </div>
+      ) : (
+        data.map((Notification) => (
+          <div
+            key={Notification.id}
+            className="h-[56px] border-b-[1px] border-[var(--color-white-stroke)] bg-[var(--color-white)] cursor-pointer">
+            <div className="ml-[12px] mt-[12px]">
+              <p className="text-[8px] text-text-on-background font-normal">{Notification.create_at}</p>
+            </div>
+            <div className="flex justify-center">
+              <div className="w-full max-w-[256px] h-[16px] flex justify-start items-center mt-[6px]">
+                <img className="w-[16px] h-[16px]" src={alarm} alt="읽음" />
+
+                <p className={`text-[12px] text-text-on-white' font-medium ml-[6px]`}>
+                  {/*20자까지만 표시 */}
+                  {Notification.content.length > 22 ? Notification.content.slice(0, 22) + '...' : Notification.content}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
   );
 }

--- a/src/pages/PromptGuidePage/PromptGuideDetailPage.tsx
+++ b/src/pages/PromptGuidePage/PromptGuideDetailPage.tsx
@@ -5,6 +5,8 @@
  * - 게시글 본문에 markdown 적용 필요
  * - 게시글 본문에 스크롤바 ui 적용 필요
  * (tailwind.config.js 설정해야 함)
+ * 추후 모바일 화면의 img-url은 이미지 변경 필요
+ * 게시글 하단의 url 링크 연결 필요
  * @author luii
  * **/
 
@@ -13,6 +15,8 @@ import { BsPaperclip } from 'react-icons/bs';
 import { LuChevronLeft } from 'react-icons/lu';
 import { useNavigate, useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
+
+import attachfile from '@assets/icon-attach-file-hover.svg';
 
 import url from '@assets/icon-linkhub-logo.svg';
 import instagram from '@assets/icon-instagram-logo.svg';
@@ -61,7 +65,7 @@ AI가 해당 프롬프트를 정상적으로 처리할 수 있도록 구성되�
     create_at: '2025-07-01',
     update_at: '2025-07-01,',
     is_visible: true,
-    file_url: null,
+    file_url: 'null',
     view_count: 1,
   });
 
@@ -72,52 +76,106 @@ AI가 해당 프롬프트를 정상적으로 처리할 수 있도록 구성되�
   };
 
   return (
-    <div className="min-h-screen flex justify-center items-center">
-      <div className="w-full max-w-[994px] h-[750px] bg-white rounded-t-[16px] rounded-b-[16px]">
-        <div className="w-full max-w-[994px] mh-[105px]  pt-[55px] pl-[20px] pr-[10px]">
-          <div
-            className="w-[187px] h-[50px] flex items-center gap-[10px] p-[10px] cursor-pointer"
-            onClick={handleNavigate}>
-            <LuChevronLeft size={24} />
-            <span className="text-text-on-white font-bold text-[24px] ">{`${type === 'tip' ? '프롬프트 TIP' : '공지사항'}`}</span>
-          </div>
-        </div>
+    <>
+      <div className="hidden lg:block">
+        <div className="min-h-screen flex justify-center items-center">
+          <div className="w-full max-w-[994px] h-[750px] bg-white rounded-t-[16px] rounded-b-[16px]">
+            {/* 상단 */}
+            <div className="w-full max-w-[994px] mh-[105px]  pt-[55px] pl-[20px] pr-[10px]">
+              <div
+                className="w-[187px] h-[50px] flex items-center gap-[10px] p-[10px] cursor-pointer"
+                onClick={handleNavigate}>
+                <LuChevronLeft size={24} />
+                <span className="text-text-on-white font-bold text-[24px] ">{`${type === 'tip' ? '프롬프트 TIP' : '공지사항'}`}</span>
+              </div>
+            </div>
 
-        <div className="w-full max-w-[994px] h-[135px] border-b-[1px] border-white-stroke px-[65px]">
-          <h1 className="font-bold text-[32px] text-text-on-white pt-[30px]">{post.title}</h1>
-          <p className="font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">{post.create_at}</p>
-        </div>
+            <div className="w-full max-w-[994px] h-[135px] border-b-[1px] border-white-stroke px-[65px]">
+              <h1 className="font-bold text-[32px] text-text-on-white pt-[30px]">{post.title}</h1>
+              <p className="font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">{post.create_at}</p>
+            </div>
 
-        <div className="w-full max-w-[994px] h-[385px] flex justify-center overflow-y-auto prose prose-neutral text-base">
-          <div className="w-[864px] border-b-[1px] border-white-stroke font-medium text-[20px] text-text-on-white py-[30px]">
-            {post.content}
-          </div>
-          {/**추후 다시 markdown 적용해보기... */}
-        </div>
+            {/* 본문 */}
+            <div className="w-full max-w-[994px] h-[385px] flex justify-center overflow-y-auto prose prose-neutral text-base">
+              <div className="w-[864px] border-b-[1px] border-white-stroke font-medium text-[20px] text-text-on-white py-[30px]">
+                {post.content}
+              </div>
+              {/**추후 다시 markdown 적용해보기... */}
+            </div>
 
-        {/**하단 */}
-        <div className="w-full max-w-[994px] h-[125px]  flex justify-center">
-          <div className="w-[864px] h-[45px] flex justify-between mt-[33px] mb-[47px]">
-            {typeof post.file_url === 'string' && post.file_url.trim() !== '' ? (
-              <button className="w-[116px] h-[45px] flex justify-center gap-[2px] items-center rounded-lg border-[1px] border-primary bg-white text-primary">
-                <BsPaperclip className="mr-2" size={20} />
-                <p className="font-medium text-primary text-[20px]">첨부</p>
-              </button>
-            ) : (
-              <div className="w-[116px] h-[45px]">{/* file_url이 null, undefined, ""일 때만 보여줌 */}</div>
-            )}
+            {/**하단 */}
+            <div className="w-full max-w-[994px] h-[125px]  flex justify-center">
+              <div className="w-[864px] h-[45px] flex justify-between mt-[33px] mb-[47px]">
+                {typeof post.file_url === 'string' && post.file_url.trim() !== '' ? (
+                  <button className="w-[116px] h-[45px] flex justify-center gap-[2px] items-center rounded-lg border-[1px] border-primary bg-white text-primary">
+                    <BsPaperclip className="mr-2" size={20} />
+                    <p className="font-medium text-primary text-[20px]">첨부</p>
+                  </button>
+                ) : (
+                  <div className="w-[116px] h-[45px]">{/* file_url이 null, undefined, ""일 때만 보여줌 */}</div>
+                )}
 
-            <div className="w-[240px] flex justify-between items-center">
-              <img src={url} alt="url" />
-              <img src={instagram} alt="instagram" />
-              <img src={facebook} alt="facebook" />
-              <img src={kakaotalk} alt="kakaotalk" />
-              <img src={twitter} alt="twitter" />
+                <div className="w-[240px] flex justify-between items-center">
+                  <img src={url} alt="url" />
+                  <img src={instagram} alt="instagram" />
+                  <img src={facebook} alt="facebook" />
+                  <img src={kakaotalk} alt="kakaotalk" />
+                  <img src={twitter} alt="twitter" />
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+
+      {/*모바일 화면 */}
+      <div className="lg:hidden block">
+        <div className="relative w-full h-12  flex items-center">
+          <button className="ml-[12px] flex items-center cursor-pointer" onClick={handleNavigate}>
+            <LuChevronLeft size={24} />
+          </button>
+          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 font-bold text-xl tracking-wide">
+            <p className="text-[16px] text-black font-medium"> {`${type === 'tip' ? '프롬프트 TIP' : '공지사항'}`}</p>
+          </span>
+        </div>
+        <div className=" flex justify-center items-center mt-[20px]">
+          <div className="w-full max-w-[280px] h-full min-h-[420px] bg-white">
+            {/*상단 */}
+            <div className="w-full max-w-[280px] h-full max-h-[80px] border-b-[0.5px] border-white-stroke px-[20px]">
+              <h1 className="font-medium text-[12px] text-text-on-white mt-[20px]">{post.title}</h1>
+              <p className="font-normal text-[8px] text-text-on-background mt-[12px] mb-[23px]">{post.create_at}</p>
+            </div>
+            {/*본문 */}
+            <div className="w-full max-w-[280px] h-full min-h-[275px] border-b-[0.5px] border-white-stroke p-[20px] ">
+              <div className="text-[10px] text-text-on-white font-medium">{post.content}</div>
+            </div>
+            {/*하단  */}
+            <div className="w-full max-w-[280px] h-[64px] flex justify-center">
+              <div className="w-full h-[45px] flex justify-center gap-[45px] items-center">
+                {typeof post.file_url === 'string' && post.file_url.trim() !== '' ? (
+                  <button
+                    className="w-[60px] h-[24px] flex justify-center gap-[4px] items-center rounded-lg border-[1px]
+                   border-primary bg-white text-primary">
+                    <img className="w-[12px] h-[12px]" src={attachfile} alt="attach-file" />
+                    <p className="font-medium text-primary text-[12px]">첨부</p>
+                  </button>
+                ) : (
+                  <div className="w-[60px] h-[24px]">{/* file_url이 null, undefined, ""일 때만 보여줌 */}</div>
+                )}
+
+                <div className="w-[135px] flex justify-between items-center">
+                  <img className="w-[16px] h-[16px]" src={url} alt="url" />
+                  <img className="w-[16px] h-[16px]" src={instagram} alt="instagram" />
+                  <img className="w-[16px] h-[16px]" src={facebook} alt="facebook" />
+                  <img className="w-[16px] h-[16px]" src={kakaotalk} alt="kakaotalk" />
+                  <img className="w-[16px] h-[16px]" src={twitter} alt="twitter" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/PromptGuidePage/PromptGuidePage.tsx
+++ b/src/pages/PromptGuidePage/PromptGuidePage.tsx
@@ -5,14 +5,17 @@
  * @author 김진효
  * **/
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Pagination, PromptTableList } from './components/Pagination';
+import { LuChevronDown } from 'react-icons/lu';
+import MobileList from './components/MobileList';
 
 /**
  * Memo
  * 1. url : guide/tip, guide/notice
  * 2. 현재 데이터를 더미데이터로 사용하는 중임
+ * 3. 1023 이하일때는 스크롤에 Throttle 처리 필요
  */
 
 interface PromptGuidePageProps {
@@ -176,34 +179,94 @@ const PromptGuidePage = ({ type }: PromptGuidePageProps) => {
     //이런 식으로 해야 함 (아마도?)
   };
 
+  // 모바일 화면 관련
+  const [open, setOpen] = useState(false);
+  const [selectedType, setSelectedType] = useState<'tip' | 'notice'>('tip');
+  const ref = useRef<HTMLDivElement>(null);
+
+  // 바깥 클릭시 닫히게
+  // useEffect(() => {
+  //   function handleClickOutside(event: MouseEvent) {
+  //     if (ref.current && !ref.current.contains(event.target as Node)) {
+  //       setOpen(false);
+  //     }
+  //   }
+  //   document.addEventListener('mousedown', handleClickOutside);
+  //   return () => document.removeEventListener('mousedown', handleClickOutside);
+  // }, []);
+
   return (
     <>
-      <div className="pl-[102px] pt-[92px]">
-        <div className="flex justify-between items-center w-full max-w-[360px] h-[60px]">
-          <button
-            onClick={() => handleTypeChange('tip')}
-            className={`${
-              type === 'tip'
-                ? 'text-primary-hover font-bold text-[32px] border-r-[2px] border-r-primary-hover'
-                : 'text-text-on-background font-bold text-[24px]'
-            } pt-[10px] pb-[10px] pr-[40px]`}>
-            프롬프트 TIP
-          </button>
+      <div className="hidden lg:block">
+        <div className="pl-[102px] pt-[92px]">
+          <div className="flex justify-between items-center w-full max-w-[360px] h-[60px]">
+            <button
+              onClick={() => handleTypeChange('tip')}
+              className={`${
+                type === 'tip'
+                  ? 'text-primary-hover font-bold text-[32px] border-r-[2px] border-r-primary-hover'
+                  : 'text-text-on-background font-bold text-[24px]'
+              } pt-[10px] pb-[10px] pr-[40px]`}>
+              프롬프트 TIP
+            </button>
 
-          <button
-            onClick={() => handleTypeChange('notice')}
-            className={`${
-              type === 'notice'
-                ? 'text-primary-hover font-bold text-[32px] border-l-[2px] border-l-primary-hover'
-                : 'text-text-on-background font-bold text-[24px]'
-            } pt-[10px] pb-[10px] pl-[40px]`}>
-            공지사항
-          </button>
+            <button
+              onClick={() => handleTypeChange('notice')}
+              className={`${
+                type === 'notice'
+                  ? 'text-primary-hover font-bold text-[32px] border-l-[2px] border-l-primary-hover'
+                  : 'text-text-on-background font-bold text-[24px]'
+              } pt-[10px] pb-[10px] pl-[40px]`}>
+              공지사항
+            </button>
+          </div>
+        </div>
+        <div>
+          <PromptTableList data={pageData} onRowClick={handleRowClick} />
+          <Pagination currentPage={currentPage} totalPages={TOTAL_PAGES} onPageChange={handlePageChange} />
         </div>
       </div>
-      <div>
-        <PromptTableList data={pageData} onRowClick={handleRowClick} />
-        <Pagination currentPage={currentPage} totalPages={TOTAL_PAGES} onPageChange={handlePageChange} />
+
+      {/*모바일 화면 */}
+      <div className="lg:hidden block">
+        <div>
+          <p className="ml-[20px] mt-[12px] text-primary-hover text-[20px] font-bold">프롬프트 TIP</p>
+        </div>
+        <div className="relative inline-block w-full max-w-[108px] h-[31px] mt-[20px] ml-[20px]" ref={ref}>
+          <button
+            type="button"
+            className="flex items-center justify-center gap-[8px] w-full px-[12px] py-[8px] rounded-[8px] bg-white"
+            style={{ boxShadow: '0px 1px 3px 0px rgba(0,0,0,0.08)' }}
+            onClick={() => setOpen((prev) => !prev)}>
+            <span className="text-[12px] text-text-on-white font-medium">
+              {type === 'tip' ? '프롬프트 TIP' : '공지사항'}
+            </span>
+            <LuChevronDown size={10} />
+          </button>
+
+          {/*이하 드롭다운은 디자인에 추가되면 해야 함 */}
+          {open && (
+            <ul className="absolute left-0 z-10 w-full mt-1 bg-white border rounded shadow">
+              <li
+                onClick={() => {
+                  navigate(`/guide/tip`);
+                  setOpen(false);
+                }}>
+                프롬프트 TIP
+              </li>
+              <li
+                onClick={() => {
+                  navigate(`/guide/notice`);
+                  setOpen(false);
+                }}>
+                공지사항
+              </li>
+            </ul>
+          )}
+        </div>
+        <div className="flex justify-center">
+          <MobileList data={allPosts} onRowClick={handleRowClick} />
+        </div>
       </div>
     </>
   );

--- a/src/pages/PromptGuidePage/PromptGuidePage.tsx
+++ b/src/pages/PromptGuidePage/PromptGuidePage.tsx
@@ -244,22 +244,33 @@ const PromptGuidePage = ({ type }: PromptGuidePageProps) => {
             <LuChevronDown size={10} />
           </button>
 
-          {/*이하 드롭다운은 디자인에 추가되면 해야 함 */}
+          {/*드롭다운 */}
           {open && (
-            <ul className="absolute left-0 z-10 w-full mt-1 bg-white border rounded shadow">
+            <ul
+              className="absolute left-0 z-10 w-[111px] h-[66px] mt-[6px] flex flex-col justify-center items-center
+               bg-white border-[0.5px] border-white-stroke rounded-[8px]"
+              style={{ boxShadow: '0px 1px 3px 0px rgba(0,0,0,0.08)' }}>
               <li
+                className="w-[87px] h-[27px] flex justify-center items-center border-b-[0.5px] border-white-stroke"
                 onClick={() => {
                   navigate(`/guide/tip`);
                   setOpen(false);
                 }}>
-                프롬프트 TIP
+                <p
+                  className={`text-[12px] font-normal ${type === 'tip' ? 'text-text-on-white' : 'text-text-on-background'}`}>
+                  프롬프트 TIP
+                </p>
               </li>
               <li
+                className="w-[87px] h-[27px] flex justify-center items-center "
                 onClick={() => {
                   navigate(`/guide/notice`);
                   setOpen(false);
                 }}>
-                공지사항
+                <p
+                  className={`text-[12px] font-normal ${type === 'notice' ? 'text-text-on-white' : 'text-text-on-background'}`}>
+                  공지사항
+                </p>
               </li>
             </ul>
           )}

--- a/src/pages/PromptGuidePage/components/MobileList.tsx
+++ b/src/pages/PromptGuidePage/components/MobileList.tsx
@@ -1,0 +1,36 @@
+import { BsPaperclip } from 'react-icons/bs';
+
+interface Postlist {
+  id: number;
+  title: string;
+  file_url: null | string;
+  create_at: string;
+}
+const MobileList = ({ data, onRowClick }: { data: Postlist[]; onRowClick: (id: number) => void }) => {
+  return (
+    <div className="w-full max-w-[280px] my-[12px] cursor-pointer flex flex-col justify-center">
+      {data.length === 0 ? (
+        <div>
+          <td colSpan={3} className="text-center py-4 text-gray-400">
+            게시글이 없습니다.
+          </td>
+        </div>
+      ) : (
+        data.map((post) => (
+          <div
+            key={post.id}
+            className="w-full max-w-[280px] h-[56px] flex flex-col justify-center border-b-[1px] border-white-stroke bg-white "
+            onClick={() => onRowClick(post.id)}>
+            <p className="ml-[12px] text-[8px] text-text-on-background font-medium">{post.create_at}</p>
+            <div className="w-full max-w-[256px] h-[16px] mx-[12px] flex justify-between items-center mt-[6px]">
+              <p className="text-[12px] text-text-on-white font-medium">{post.title}</p>
+              <div>{post.file_url ? <BsPaperclip size={16} /> : ''}</div>
+            </div>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default MobileList;


### PR DESCRIPTION
<!-- [태그] 작업 요약 -->

### 📑 이슈번호

- close #62 

### ✨️ 작업 내용

프롬프트 TIP, 공지사항, 마이페이지 메시지함, 알림함 기본 페이지
프롬프트 TIP, 공지사항, 마이페이지 메시지함 상세 페이지
모바일 반응형 UI 작업 완료했습니다.

### 💭 코멘트

스크롤 UI 적용과 상세페이지의 마크다운 적용 부분에서 오류가 있어 추후 개발에 반영하겠습니다.
스크롤 UI의 경우, index.css에 작성되어 있는 내용을 사용하면 되는지 궁금합니다.
마크다운은.... 제가 방법을 찾아보겠습니다...

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
<img width="380" height="670" alt="image" src="https://github.com/user-attachments/assets/ce18e848-0b52-49d5-bac5-3d3bf0f4536a" />
<img width="399" height="648" alt="image" src="https://github.com/user-attachments/assets/6af8799f-6f9f-4404-a387-d4527958fbfe" />
<img width="387" height="670" alt="image" src="https://github.com/user-attachments/assets/716ab899-a089-491a-8664-d6f95aa12ea4" />

<img width="397" height="429" alt="image" src="https://github.com/user-attachments/assets/688d8f4b-d292-45c5-9845-df74d9e353cf" />
<img width="395" height="668" alt="image" src="https://github.com/user-attachments/assets/549058b3-1857-449c-832d-e9f513711dcb" />
<img width="377" height="680" alt="image" src="https://github.com/user-attachments/assets/07c1602b-c7a3-4c26-8697-b1eb9141d9a8" />

