### PR TITLE
[Fix] 공통 컴포넌트 및 프로필 홈 수정

### DIFF
--- a/src/components/CoachMark.tsx
+++ b/src/components/CoachMark.tsx
@@ -25,7 +25,7 @@ const CoachMark = ({ setShowCoachMark }: CoachMarkProps) => {
   const { accessToken } = useAuth();
 
   return (
-    <div className="fixed inset-0 bg-overlay-coach-mark z-20">
+    <div className="fixed inset-0 bg-overlay-coach-mark z-20 max-lg:hidden">
       <div className="absolute inset-0 z-30" onClick={() => setShowCoachMark(false)}></div>
       <nav className="relative flex justify-between items-center gap-[2.6vw] py-[7.5px] pl-[61.25px] pr-[36px] z-[10]">
         <div className="cursor-pointer w-[227px] shrink-0"></div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -63,7 +63,7 @@ const Navbar = () => {
             onChange={(e) => setSearch(e.target.value)}
             onKeyDown={(e) => handleKeyDown(e)}
             placeholder="내가 원하는 프롬프트 찾기"
-            className="flex-1 placeholder:font-SpoqaHanSansNeo placeholder:color-text-on-background placeholder:text-base placeholder:font-normal placeholder:leading-[26px] placeholder:tracking-[0.46px] bg-background rounded-[40px] border border-[#ccc] py-[10px] px-[20px] outline-none focus:border focus:border-primary focus:inset-shadow-inner max-lg:min-w-[220px] max-lg:w-full"
+            className="flex-1 placeholder:font-SpoqaHanSansNeo placeholder:color-text-on-background placeholder:text-base placeholder:font-normal placeholder:leading-[26px] placeholder:tracking-[0.46px] bg-background rounded-[40px] border border-[#ccc] py-[10px] max-lg:py-[6.5px] px-[20px] outline-none focus:border focus:border-primary focus:inset-shadow-inner max-lg:min-w-[220px] max-lg:w-full max-lg:text-[10px] max-lg:font-normal max-lg:leading-[13px] max-lg:tracking-[0.46px] max-lg:placeholder:text-[10px] max-lg:placeholder:font-normal max-lg:placeholder:leading-[13px] max-lg:placeholder:tracking-[0.46px]"
           />
           <HiMagnifyingGlass
             onClick={handleSearch}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -44,7 +44,7 @@ const TabBar = () => {
 
   return (
     <>
-      <div className="fixed bottom-0 max-w-[425px] w-full">
+      <div className="fixed bottom-0 max-w-[425px] w-full z-100">
         <div className="max-w-[425px] w-full max-h-[95px] flex items-end">{activeLink?.tab}</div>
 
         <div className="flex justify-evenly items-center absolute inset-0 z-100  w-full">

--- a/src/hooks/useShowLoginModal.ts
+++ b/src/hooks/useShowLoginModal.ts
@@ -1,0 +1,46 @@
+import { useAuth } from '@/context/AuthContext';
+import { useState } from 'react';
+
+/**
+ * accessToken이 없는 경우 로그인 모달을 띄워주는 훅입니다.
+ * 로그인하지 않은 상태라면 로그인 모달,
+ * 로그인된 상태라면 전달받은 콜백함수를 실행합니다.
+ *
+ * @returns {
+ *    loginModalShow: boolean,  // 로그인 모달 표시 여부
+ *    setLoginModalShow: React.Dispatch<React.SetStateAction<boolean>>,  // 모달 상태 제어 함수
+ *    handleShowLoginModal: (callback: () => void) => void,  // 로그인된 상태에 실행할 함수
+ * }
+ *
+ * @example
+ * const { loginModalShow, setLoginModalShow, handleShowLoginModal } = useShowLoginModal();
+ *
+ * const handleFollow = () => {
+ *   handleShowLoginModal(() => {
+ *     setIsFollow((prev) => !prev); // 로그인된 경우 실행할 함수
+ *   });
+ * };
+ *
+ * <FollowButton follow={isFollow} onClick={handleFollow} size="lg" />
+ *
+ * {loginModalShow && (
+ *   <SocialLoginModal isOpen={loginModalShow} onClose={() => setLoginModalShow(false)} onClick={() => {}} />
+ * )}
+ *
+ * @author 김진효
+ * **/
+
+export const useShowLoginModal = () => {
+  const { accessToken } = useAuth();
+  const [loginModalShow, setLoginModalShow] = useState(false);
+
+  const handleShowLoginModal = (callback: () => void) => {
+    if (!accessToken) {
+      setLoginModalShow(true);
+    } else {
+      callback();
+    }
+  };
+
+  return { loginModalShow, setLoginModalShow, handleShowLoginModal };
+};

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -26,6 +26,7 @@ import PrimaryButton from '@components/Button/PrimaryButton';
 import InquiryCard from './components/InquiryCard';
 import InquiryDetailCard from './components/InquiryDetailCard';
 import FollowCard from './components/FollowCard';
+import SocialLoginModal from '@/components/Modal/SocialLoginModal';
 
 import DESCRIPTION from '@data/ProfilePage/description.json';
 import PROMPT from '@data/ProfilePage/prompt.json';
@@ -36,6 +37,7 @@ import FOLLOWER from '@data/ProfilePage/follower.json';
 
 import useImgUpload from '@hooks/useImgUpload';
 import Select from './components/Select';
+import { useShowLoginModal } from '@/hooks/useShowLoginModal';
 
 const USER = {
   member_id: 12345,
@@ -59,6 +61,8 @@ const ProfilePage = () => {
   const { id } = useParams();
   const myId = localStorage.getItem('user_id'); // 로그인 시 저장 필요
   const isMyProfile = id === myId; // 현재 10인 경우 본인 페이지로 이동됨
+
+  const { loginModalShow, setLoginModalShow, handleShowLoginModal } = useShowLoginModal();
 
   const [descriptions, setDescriptions] = useState(DESCRIPTION.map((d) => ({ ...d, isEditing: false })));
 
@@ -106,6 +110,12 @@ const ProfilePage = () => {
   ];
 
   const [menuId, setMenuId] = useState(0);
+
+  const handleFollow = () => {
+    handleShowLoginModal(() => {
+      setIsFollow((prev) => !prev);
+    });
+  };
 
   const handleDeletePrompts = (id: number) => {
     setPrompts((prev) => prev.filter((p) => p.prompt_id !== id));
@@ -332,25 +342,13 @@ const ProfilePage = () => {
               </div>
 
               <div className="lg:hidden max-lg:ml-[3px]">
-                <FollowButton
-                  follow={isFollow}
-                  onClick={() => {
-                    setIsFollow((prev) => !prev);
-                  }}
-                  size="sm"
-                />
+                <FollowButton follow={isFollow} onClick={handleFollow} size="sm" />
               </div>
             </div>
 
             <div className="flex gap-[24px] items-center max-lg:hidden">
               <div className="max-lg:hidden">
-                <FollowButton
-                  follow={isFollow}
-                  onClick={() => {
-                    setIsFollow((prev) => !prev);
-                  }}
-                  size="lg"
-                />
+                <FollowButton follow={isFollow} onClick={handleFollow} size="lg" />
               </div>
 
               <div
@@ -668,6 +666,9 @@ const ProfilePage = () => {
           )}
         </div>
       </div>
+      {loginModalShow && (
+        <SocialLoginModal isOpen={loginModalShow} onClose={() => setLoginModalShow(false)} onClick={() => {}} />
+      )}
     </div>
   );
 };

--- a/src/pages/ProfilePage/components/AskCard.tsx
+++ b/src/pages/ProfilePage/components/AskCard.tsx
@@ -52,10 +52,7 @@ const AskCard = ({ prompts, isMyProfile, type, setType }: AskCardProps) => {
                 <div
                   onClick={() => setIsListClicked((prev) => !prev)}
                   className="group w-[24px] h-[24px] max-lg:w-[16px] max-lg:h-[16px] max-lg:py-[2px] max-lg:px-[6px] cursor-pointer flex items-center justify-center hover:bg-secondary-pressed rounded-full">
-                  <img
-                    src={DotsIcon}
-                    className="text-white group-hover:text-text-on-white w-full h-full object-contain"
-                  />
+                  <img src={DotsIcon} className="text-white group-hover:text-text-on-white" />
                 </div>
                 {isListClicked && (
                   <div className="absolute top-[34px] left-0 right-0 rounded-[4px] flex flex-col">

--- a/src/pages/ProfilePage/components/AskCard.tsx
+++ b/src/pages/ProfilePage/components/AskCard.tsx
@@ -41,7 +41,7 @@ const AskCard = ({ prompts, isMyProfile, type, setType }: AskCardProps) => {
           <div className="relative bg-white border-b border-b-white-stroke px-[65px] pt-[55px] max-lg:p-[12px] text-text-on-white text-[20px] font-medium leading-[25px] max-lg:min-h-[214px] max-lg:mt-[-30px]">
             <textarea
               placeholder="문의할 내용을 입력하세요"
-              className="text-text-on-background text-[20px] font-medium leading-[25px] w-full min-h-[409px] max-lg:min-h-[190px] outline-none resize-none max-lg:pt-[38px] max-lg:text-[10px] max-lg:font-normal max-lg:leading-[13px]"
+              className="placeholder:font-SpoqaHanSansNeo placeholder:text-text-on-background text-[20px] font-medium leading-[25px] w-full min-h-[409px] max-lg:min-h-[190px] outline-none resize-none max-lg:pt-[38px] max-lg:text-[10px] max-lg:font-normal max-lg:leading-[13px]"
             />
 
             <div className="flex gap-[32px] items-center justify-end w-full absolute right-[32px] bottom-[34px] max-lg:static">


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #94 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

> 공통 컴포넌트 및 프로필 홈 관련 QA 사항 수정했습니다.

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

#### useShowLoginModal 훅 작성
로그인 안 된 사용자가 클릭 시 로그인 모달 띄우는 부분이 반복적으로 나타나서 `useAuth`에서 `accessToken` 가져온 후 

> 로그인 안 된 사용자 -> `로그인 모달 보여주기`
> 로그인 된 사용자 -> `콜백함수 실행`

에 해당하는 내용을 `useShowLoginModal` 훅으로 작성해두었습니다.
필요하신 분들은 참고하여 수정해주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

| `헤더` |  `tabbar z-index` | `프로필 홈` | `로그인 모달` |
| ----- | ----- | ----- | ----- |
| <img width="944" height="138" alt="image" src="https://github.com/user-attachments/assets/f6b685fe-0523-4163-b0de-437cefcba166" /> | <img width="740" height="294" alt="image" src="https://github.com/user-attachments/assets/b52c1ffc-0cec-4c42-9d73-0cf899c89b23" /> | <img width="2080" height="1060" alt="image" src="https://github.com/user-attachments/assets/25571663-1c86-48dc-a0c8-7ac0609452ed" /> | <img width="3420" height="1696" alt="image" src="https://github.com/user-attachments/assets/b01ca71e-37ab-455a-b034-8d6643a7f080" /> |



