### PR TITLE
[Feat] 마이페이지 메시지 함 & 알림함 API 연동

### DIFF
--- a/src/pages/MyPage/MyMessageDetailPage.tsx
+++ b/src/pages/MyPage/MyMessageDetailPage.tsx
@@ -5,7 +5,8 @@
  * @author 김진효
  * **/
 
-import { useState } from 'react';
+import { axiosInstance } from '@/apis/axios';
+import { useEffect, useState } from 'react';
 import { LuChevronLeft } from 'react-icons/lu';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -13,37 +14,22 @@ interface MyMessageDetailPageProps {
   type: 'message' | 'notification';
 }
 interface Message {
-  id: number; //message_id
-  sender_id: string; // erd 상에서는 num이지만... 편의상 string으로 수정
-  receiver_id: string;
+  message_id: number; //message_id
+  sender_nickname: string;
   title: string;
-  body: string;
+  content: string;
   is_read: boolean;
-  read_at: string;
-  is_deleted: boolean;
-  create_at: string;
-  update_at: string;
+  created_at: string;
 }
 const MyMessageDetailPage = ({ type }: MyMessageDetailPageProps) => {
   const { id } = useParams<{ id: string }>();
   const [message, setMessage] = useState<Message>({
-    id: Number(id),
-    sender_id: '관리자',
-    receiver_id: '주토피아노',
-    title: '프롬프트 가이드라인 위반 경고',
-    body: `안녕하세요 주토피아노님. 
-    주토피아노님의 “파이썬으로 5분만에 구슬깨기 게임 만들어주는 프롬프트”가 프롬프트 가이드라인을 위반한 것으로 확인되었습니다.
-    해당 프롬프트는 설명 내용이 실제 결과와 다르거나,사용자가 기대할 수 있는 기능을 과도하게 부풀려 안내하고 있어허위 또는 과장된 콘텐츠로 판단되었습니다.
-    PromptPlace는 사용자 간의 신뢰를 바탕으로 운영되며,정확하고 성실한 정보 제공은 모든 창작자의 기본 의무입니다.
-    이에 따라 해당 프롬프트는 일시적으로 비공개 처리되었으며,가이드라인에 맞게 수정하신 후 다시 등록하실 수 있습니다.
-    가이드라인 전문은 [업로드 가이드라인 보기] 링크를 통해 확인하실 수 있습니다.또한, 추가 문의 사항이 있으실 경우 언제든지 고객센터로 연락주시기 바랍니다.
-    앞으로도 더 나은 프롬프트 생태계를 함께 만들어주시길 바랍니다.
-    감사합니다. PromptPlace 운영팀 드림.`,
+    message_id: Number(id),
+    sender_nickname: '작성자',
+    title: '제목',
+    content: `본문`,
     is_read: true,
-    read_at: '2025-07-22',
-    is_deleted: false,
-    create_at: '2025-07-22',
-    update_at: '2025-07-22',
+    created_at: '2025-07-22',
   });
 
   const navigate = useNavigate();
@@ -51,12 +37,32 @@ const MyMessageDetailPage = ({ type }: MyMessageDetailPageProps) => {
     navigate(`/mypage/message/message`);
   };
 
+  useEffect(() => {
+    const fetchMessageDetail = async () => {
+      const base = import.meta.env.VITE_SERVER_API_URL;
+      const res = await axiosInstance.get(`${base}/api/messages/${id}`);
+      const formattedMessage: Message = {
+        message_id: res.data.message_id,
+        sender_nickname: res.data.sender,
+        title: res.data.title,
+        content: res.data.content,
+        is_read: res.data.is_read,
+        created_at: res.data.created_at.slice(0, 10),
+      };
+      setMessage(formattedMessage);
+      try {
+      } catch (error) {
+        console.error(`상세 메시지 내용 불러오기 실패:`, error);
+      }
+    };
+    fetchMessageDetail();
+  }, [id]);
+
   return (
     <>
       <div className="hidden lg:block">
-        {' '}
-        <div className="min-h-[calc(100vh-24px)] bg-background flex justify-center items-center ">
-          {/**min-h-[calc(100vh-24px)] : 추후 min-h 부분은 navbar에 따라서 수정 필요 */}
+        <div className="pt-[35px] bg-background flex justify-center items-center">
+          {/**min-h-[calc(100vh-24px)] : pt 오류나면 이걸로 고쳐야 함 */}
           <div className="w-[994px] h-[868px] bg-white rounded-t-[16px] rounded-b-[16px]">
             <div className="w-[994px] h-[105px] pt-[35px] pl-[20px] pr-[10px]">
               <div className="w-[187px] h-[50px] flex items-center gap-[10px] p-[10px]" onClick={handleNavigate}>
@@ -69,17 +75,17 @@ const MyMessageDetailPage = ({ type }: MyMessageDetailPageProps) => {
               <h1 className="font-bold text-[32px] text-text-on-white pt-[30px]">{message.title}</h1>
               <div className="w-[404px]  flex justify-between gap-[10px] items-center">
                 <p className="w-[197px] font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">
-                  {message.create_at}
+                  {message.created_at}
                 </p>
                 <p className="w-[197px] font-medium text-[20px] text-text-on-background pt-[10px] pb-[30px]">
-                  보낸 사람 : {message.sender_id}
+                  보낸 사람 : {message.sender_nickname}
                 </p>
               </div>
             </div>
 
             <div className="w-[994px] h-[485px] flex justify-center overflow-y-auto prose prose-neutral max-w-none text-base">
               <div className="w-[864px] border-b-[1px] border-white-stroke font-medium text-[20px] text-text-on-white py-[30px]">
-                {message.body}
+                {message.content}
               </div>
               {/**추후 다시 markdown 적용해보기... */}
             </div>
@@ -108,13 +114,13 @@ const MyMessageDetailPage = ({ type }: MyMessageDetailPageProps) => {
             <div className="w-full max-w-[280px] h-full max-h-[80px] border-b-[0.5px] border-white-stroke px-[20px]">
               <h1 className="font-medium text-[12px] text-text-on-white mt-[20px]">{message.title}</h1>
               <div className="h-[13px] flex justify-start items-center mt-[12px] mb-[23px] gap-[24px]">
-                <p className="font-normal text-[8px] text-text-on-background ">{message.create_at}</p>
-                <p className="font-medium text-[10px] text-text-on-white">보낸 사람 : {message.sender_id}</p>
+                <p className="font-normal text-[8px] text-text-on-background ">{message.created_at}</p>
+                <p className="font-medium text-[10px] text-text-on-white">보낸 사람 : {message.sender_nickname}</p>
               </div>
             </div>
             {/*본문 */}
             <div className="w-full max-w-[280px] h-full min-h-[275px] border-white-stroke p-[20px] ">
-              <div className="text-[10px] text-text-on-white font-medium">{message.body}</div>
+              <div className="text-[10px] text-text-on-white font-medium">{message.content}</div>
             </div>
           </div>
         </div>

--- a/src/pages/MyPage/MyMessagePage.tsx
+++ b/src/pages/MyPage/MyMessagePage.tsx
@@ -5,89 +5,38 @@
  * @author 김진효
  * **/
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MessageTableList, MessagePagination, MobileMessage } from './components/MessagePagination';
 import { NotificationTableList, NotificationPagination, MobileNotification } from './components/NotificationPagination';
 
 import { LuChevronDown } from 'react-icons/lu';
+import { axiosInstance } from '@/apis/axios';
 
 interface MyMessagePageProps {
   type: 'message' | 'notification';
 }
 //메시지함
 interface Message {
-  id: number; //message_id
-  sender_id: string; // erd 상에서는 num이지만... 편의상 string으로 수정
-  receiver_id: string;
+  message_id: number;
+  sender: string;
   title: string;
-  body: string;
+  created_at: string;
   is_read: boolean;
-  read_at: string;
-  is_deleted: boolean;
-  create_at: string;
-  update_at: string;
-}
-// 더미 데이터 (추후 api 연동시 삭제 또는 수정)
-const allMessages: Message[] = [
-  {
-    id: 1,
-    sender_id: '관리자',
-    receiver_id: '아메리카노',
-    title: '프롬프트 가이드라인 위반 경고',
-    body: '본문',
-    is_read: false,
-    read_at: '2025-07-08',
-    is_deleted: false,
-    create_at: '2025-07-08',
-    update_at: '2025-07-08',
-  },
-  {
-    id: 2,
-    sender_id: '홍길동',
-    receiver_id: '아메리카노',
-    title: '홍길동님이 주토피아노님의 문의에 답변을 남기셨습니다.',
-    body: '본문',
-    is_read: true,
-    read_at: '2025-07-08',
-    is_deleted: false,
-    create_at: '2025-04-12',
-    update_at: '2025-04-12',
-  },
-];
-//알림
-interface Notification {
-  id: number; //notification_id
-  content: string;
-  create_at: string;
-  user_id: string;
 }
 
-const allNotification: Notification[] = [
-  { id: 1, content: '프롬프트에 새로운 문의가 도착했습니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 2, content: '신고가 접수되었습니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 3, content: '‘홍길동’님이 새 프롬프트를 업로드하셨습니다. ', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 4, content: '‘콩쥐’님이 새 프롬프트를 업로드하셨습니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 5, content: '‘뽀또’님이 회원님을 팔로우합니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 6, content: '프롬프트에 새로운 문의가 도착했습니다. ', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 7, content: '프롬프트에 새로운 문의가 도착했습니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-  { id: 8, content: '신고가 접수되었습니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-  {
-    id: 9,
-    content: '‘아메리카노’님이 새 프롬프트를 업로드하셨습니다. ',
-    create_at: '2025-07-22',
-    user_id: '주토피아노',
-  },
-  { id: 10, content: '프롬프트에 새로운 문의가 도착했습니다.', create_at: '2025-07-22', user_id: '주토피아노' },
-];
-// 페이지 값 계산
-const PAGE_SIZE = 8;
-const TOTAL_MESSAGE_PAGES = Math.ceil(allMessages.length / PAGE_SIZE);
-const TOTAL_Notification_PAGES = Math.ceil(allNotification.length / PAGE_SIZE);
+//알림
+interface Notification {
+  notification_id: number;
+  content: string;
+  created_at: string;
+  link_url: string | null;
+}
 
 const MyMessagePage = ({ type }: MyMessagePageProps) => {
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [messages, setMessages] = useState<Message[]>(allMessages); // allMessages 복제
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [notice, setNotice] = useState<Notification[]>([]);
   const navigate = useNavigate();
 
   const handleTypeChange = (nextType: 'message' | 'notification') => {
@@ -97,31 +46,122 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
     }
   };
 
+  useEffect(() => {
+    const fetchAllPosts = async () => {
+      try {
+        if (type === 'message') {
+          const base = import.meta.env.VITE_SERVER_API_URL;
+          const res = await axiosInstance.get(`${base}/api/messages`, {
+            params: {
+              page: 1,
+              size: 30,
+            },
+          });
+
+          console.log('message 받은 데이터', res.data.messages);
+
+          const mapped: Message[] = res.data.messages.map((item: any) => ({
+            message_id: item.message_id,
+            sender: item.sender,
+            title: item.title,
+            created_at: item.created_at,
+            is_read: item.is_read,
+          }));
+
+          setMessages(mapped);
+        } else if (type === 'notification') {
+          const base = import.meta.env.VITE_SERVER_API_URL;
+          const res = await axiosInstance.get(`${base}/api/notifications/me`, {
+            params: {
+              page: 1,
+              limit: 30,
+            },
+          });
+          console.log('noti 받은 데이터', res.data.data.notifications);
+
+          const mapped: Notification[] = res.data.data.notifications.map((item: any, index: number) => {
+            let link: string | null = item.link_url;
+            console.log(`${index}번째 처리 전 link:`, link);
+
+            if (link) {
+              if (link.includes('/inquires/') || link.includes('/inquiries/')) {
+                // 두 경우 모두 처리 (백엔드 수정 전까지 임시)
+                //inquiries가 맞음 (원래는)
+                link = '/mypage';
+              } else if (link.includes('/announcements/')) {
+                console.log(`${index}번째: announcements 변환`);
+                const segs = link.split('/').filter(Boolean);
+                const id = segs[segs.length - 1];
+                link = `/guide/notice/${id}`;
+              }
+            }
+
+            console.log(`${index}번째 처리 후 link:`, link);
+
+            return {
+              notification_id: item.notification_id,
+              content: item.content,
+              created_at: item.created_at.slice(0, 10),
+              link_url: link,
+            };
+          });
+
+          console.log('최종 결과:', mapped);
+
+          setNotice(mapped);
+        }
+      } catch (error) {
+        console.error(`${type === 'message' ? '메시지' : '알림'} 불러오기 실패:`, error);
+      }
+    };
+
+    fetchAllPosts();
+  }, [type]);
+
+  console.log(notice);
+
+  // 페이지 값 계산
+  const PAGE_SIZE = 8;
+  const TOTAL_MESSAGE_PAGES = Math.ceil(messages.length / PAGE_SIZE);
+  const TOTAL_Notification_PAGES = Math.ceil(notice.length / PAGE_SIZE);
+
   // 페이지별 데이터 슬라이싱
   const pageMessageData = messages.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
-  const pageNotificationData = allNotification.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+  const pageNotificationData = notice.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
 
   // 페이지네이션에서 페이지 변경시
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
   };
-  const handleRowClick = (id: number) => {
+  const handleMessageRowClick = (id: number) => {
     navigate(`/mypage/message/message/${id}`);
   };
 
   // 메시지 삭제
   const handleDelete = (id: number) => {
-    setMessages((prev) => prev.filter((msg) => msg.id !== id));
+    setMessages((prev) => prev.filter((msg) => msg.message_id !== id));
   };
 
   // 메시지 읽음
   const handleRead = (id: number) => {
-    setMessages((prev) => prev.map((msg) => (msg.id === id ? { ...msg, is_read: true } : msg)));
+    setMessages((prev) => prev.map((msg) => (msg.message_id === id ? { ...msg, is_read: true } : msg)));
   };
 
-  //모바일 화면
+  //모바일 화면 전용
   const [openType, setOpenType] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+
+  //알림 이동
+  const handleNoticeRowClick = (noticelink: string | null) => {
+    if (!noticelink) return; // 링크 없으면 무시
+    //혹시 모를 외부경로
+    if (/^https?:\/\//.test(noticelink)) {
+      window.location.href = noticelink;
+    } else {
+      navigate(noticelink);
+    }
+  };
+
   return (
     <>
       <div className="hidden lg:block">
@@ -155,7 +195,7 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
               <>
                 <MessageTableList
                   data={pageMessageData}
-                  onRowClick={handleRowClick}
+                  handleMessageRowClick={handleMessageRowClick}
                   onDelete={handleDelete}
                   onRead={handleRead}
                 />
@@ -167,7 +207,7 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
               </>
             ) : (
               <>
-                <NotificationTableList data={pageNotificationData} />
+                <NotificationTableList data={pageNotificationData} handleNoticeRowClick={handleNoticeRowClick} />
                 <NotificationPagination
                   currentPage={currentPage}
                   totalPages={TOTAL_Notification_PAGES}
@@ -232,7 +272,7 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
             <>
               <MobileMessage
                 data={pageMessageData}
-                onRowClick={handleRowClick}
+                handleMessageRowClick={handleMessageRowClick}
                 onDelete={handleDelete}
                 onRead={handleRead}
               />

--- a/src/pages/MyPage/MyMessagePage.tsx
+++ b/src/pages/MyPage/MyMessagePage.tsx
@@ -307,7 +307,7 @@ const MyMessagePage = ({ type }: MyMessagePageProps) => {
             </>
           ) : (
             <>
-              <MobileNotification data={pageNotificationData} />
+              <MobileNotification data={pageNotificationData} handleNoticeRowClick={handleNoticeRowClick} />
             </>
           )}
         </div>

--- a/src/pages/MyPage/components/MessagePagination.tsx
+++ b/src/pages/MyPage/components/MessagePagination.tsx
@@ -8,21 +8,21 @@ import { useEffect, useRef, useState } from 'react';
 import kebabMenu from '@/assets/icon-kebabMenu.svg';
 
 interface MessageList {
-  id: number;
+  message_id: number;
   title: string;
+  sender: string;
+  created_at: string;
   is_read: boolean;
-  sender_id: string;
-  create_at: string;
 }
 // 페이지네이션 테이블
 export const MessageTableList = ({
   data,
-  onRowClick,
+  handleMessageRowClick,
   onDelete,
   onRead,
 }: {
   data: MessageList[];
-  onRowClick: (id: number) => void;
+  handleMessageRowClick: (id: number) => void;
   onDelete: (id: number) => void;
   onRead: (id: number) => void;
 }) => {
@@ -54,7 +54,7 @@ export const MessageTableList = ({
         ) : (
           data.map((message) => (
             <tr
-              key={message.id}
+              key={message.message_id}
               className="h-[65px] py-[10px] border-b-[1px]  border-white-stroke bg-white cursor-pointer">
               <td className="w-[72px] h-[65px] flex justify-center items-center pt-[13px]">
                 {message.is_read ? (
@@ -65,28 +65,30 @@ export const MessageTableList = ({
               </td>
               <td
                 className="w-[563px] h-[65px] text-left font-medium text-[20px] text-text-on-white py-[20px]"
-                onClick={() => onRowClick(message.id)}>
+                onClick={() => handleMessageRowClick(message.message_id)}>
                 <p className="h-[25px]">{message.title}</p>
               </td>
-              <td className=" w-[223px] h-[65px] px-[10px] py-[20px]" onClick={() => onRowClick(message.id)}>
+              <td
+                className=" w-[223px] h-[65px] px-[10px] py-[20px]"
+                onClick={() => handleMessageRowClick(message.message_id)}>
                 <p className="flex justify-center items-center font-medium text-[20px] text-text-on-white">
-                  {message.sender_id}
+                  {message.sender}
                 </p>
               </td>
               <td
                 className="w-[263px] h-[65px] text-center font-medium text-[20px] text-text-on-white py-[20px]"
-                onClick={() => onRowClick(message.id)}>
-                {message.create_at}
+                onClick={() => handleMessageRowClick(message.message_id)}>
+                {message.created_at}
               </td>
               <td className="w-[115px] h-[65px] flex justify-center py-[16px]">
                 <div className="relative">
                   <button
-                    onClick={() => setOpenId(openId === message.id ? null : message.id)}
+                    onClick={() => setOpenId(openId === message.message_id ? null : message.message_id)}
                     className="flex justify-center items-center w-[28px] h-[28px] rounded-full hover:bg-secondary-pressed">
                     <img className="w-[28px] h-[28px]" src={kebabMenu} alt="...버튼" />
                   </button>
                   {/*드롭다운 */}
-                  {openId === message.id && (
+                  {openId === message.message_id && (
                     <div
                       ref={menuRef}
                       className="z-30 absolute top-[40px] -left-[5px] bg-secondary rounded-[4px]
@@ -95,7 +97,7 @@ export const MessageTableList = ({
                         className="w-[91px] h-[36px] flex text-center items-center text-gray-500 rounded-t-[4px] px-[16px] py-[8px]
                       border-b-[1px] border-white-stroke"
                         onClick={() => {
-                          onDelete(message.id);
+                          onDelete(message.message_id);
                           setOpenId(null);
                         }}>
                         <p className="h-[20px] font-[400] text-[16px] text-text-on-background -translate-y-[2px]">
@@ -105,7 +107,7 @@ export const MessageTableList = ({
                       <button
                         className="w-[91px] h-[36px] flex text-center items-center text-gray-500 rounded-b-[4px] px-[16px] py-[8px]"
                         onClick={() => {
-                          onRead(message.id);
+                          onRead(message.message_id);
                           setOpenId(null);
                         }}>
                         <p className="h-[20px] font-[400] text-[16px] text-text-on-background -translate-y-[2px]">
@@ -176,12 +178,12 @@ export function MessagePagination({
 // 모바일 화면
 export const MobileMessage = ({
   data,
-  onRowClick,
+  handleMessageRowClick,
   onDelete,
   onRead,
 }: {
   data: MessageList[];
-  onRowClick: (id: number) => void;
+  handleMessageRowClick: (id: number) => void;
   onDelete: (id: number) => void;
   onRead: (id: number) => void;
 }) => {
@@ -207,27 +209,27 @@ export const MobileMessage = ({
       ) : (
         data.map((message) => (
           <div
-            key={message.id}
+            key={message.message_id}
             className="w-full max-w-[280px] h-[81px] flex flex-col justify-center border-b-[1px] border-white-stroke bg-white ">
             <div className="flex justify-center">
               <div className="flex justify-between w-full max-w-[256px]">
-                <p className="text-[8px] text-text-on-background font-normal">{message.create_at}</p>
+                <p className="text-[8px] text-text-on-background font-normal">{message.created_at}</p>
                 <div className="relative">
                   <button
-                    onClick={() => setOpenId(openId === message.id ? null : message.id)}
+                    onClick={() => setOpenId(openId === message.message_id ? null : message.message_id)}
                     className={`flex items-center justify-center h-[16px] w-[16px] rounded-[50px] ${
-                      openId === message.id ? 'bg-secondary-pressed' : 'bg-transparent'
+                      openId === message.message_id ? 'bg-secondary-pressed' : 'bg-transparent'
                     }`}>
                     <img className="w-[10px] h-[10px]" src={kebabMenu} alt="...버튼" />
                   </button>
                   {/*드롭다운 */}
-                  {openId === message.id && (
+                  {openId === message.message_id && (
                     <div
                       className="absolute right-0 top-full mt-[11px] w-[91px] bg-white rounded-md shadow-lg z-10"
                       ref={menuRef}>
                       <button
                         onClick={() => {
-                          onDelete(message.id);
+                          onDelete(message.message_id);
                           setOpenId(null);
                         }}
                         className="block w-full h-[36px] text-[16px] border-b-[1px] border-b-white-stroke text-text-on-background bg-secondary active:bg-secondary-pressed rounded-t-[4px]">
@@ -235,7 +237,7 @@ export const MobileMessage = ({
                       </button>
                       <button
                         onClick={() => {
-                          onRead(message.id);
+                          onRead(message.message_id);
                           setOpenId(null);
                         }}
                         className="block w-full h-[36px] text-[16px] text-text-on-background bg-secondary active:bg-secondary-pressed rounded-b-[4px]">
@@ -249,7 +251,7 @@ export const MobileMessage = ({
             <div className="flex justify-center">
               <div
                 className="w-full max-w-[256px] h-[16px] flex justify-start items-center mt-[6px]"
-                onClick={() => onRowClick(message.id)}>
+                onClick={() => handleMessageRowClick(message.message_id)}>
                 {message.is_read ? (
                   <img className="w-[16px] h-[16px]" src={read} alt="읽음" />
                 ) : (
@@ -266,7 +268,7 @@ export const MobileMessage = ({
               <div className="w-full max-w-[256px] h-[16px] flex justify-start items-center mt-[6px]">
                 <p
                   className={`text-[10px] ${message.is_read ? 'text-text-on-background' : 'text-text-on-white'} font-medium`}>
-                  {message.sender_id}
+                  {message.sender}
                 </p>
               </div>
             </div>

--- a/src/pages/MyPage/components/NotificationPagination.tsx
+++ b/src/pages/MyPage/components/NotificationPagination.tsx
@@ -99,7 +99,13 @@ export function NotificationPagination({
 }
 
 // 모바일 화면
-export function MobileNotification({ data }: { data: NotificationList[] }) {
+export function MobileNotification({
+  data,
+  handleNoticeRowClick,
+}: {
+  data: NotificationList[];
+  handleNoticeRowClick: (noticelink: string | null) => void;
+}) {
   return (
     <div className="w-full max-w-[280px] my-[12px] cursor-pointer flex flex-col justify-center">
       {data.length === 0 ? (
@@ -110,6 +116,7 @@ export function MobileNotification({ data }: { data: NotificationList[] }) {
         data.map((Notification) => (
           <div
             key={Notification.notification_id}
+            onClick={() => handleNoticeRowClick(Notification.link_url)}
             className="h-[56px] border-b-[1px] border-[var(--color-white-stroke)] bg-[var(--color-white)] cursor-pointer">
             <div className="ml-[12px] mt-[12px]">
               <p className="text-[8px] text-text-on-background font-normal">{Notification.created_at}</p>

--- a/src/pages/MyPage/components/NotificationPagination.tsx
+++ b/src/pages/MyPage/components/NotificationPagination.tsx
@@ -3,12 +3,19 @@ import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 import alarm from '@assets/icon-alarm-black.svg';
 
 interface NotificationList {
-  id: number; //notification_id
+  notification_id: number; //notification_id
   content: string;
-  create_at: string;
+  created_at: string;
+  link_url: string | null;
 }
 // 페이지네이션 테이블
-export function NotificationTableList({ data }: { data: NotificationList[] }) {
+export function NotificationTableList({
+  data,
+  handleNoticeRowClick,
+}: {
+  data: NotificationList[];
+  handleNoticeRowClick: (noticelink: string | null) => void;
+}) {
   return (
     <table className="w-full max-w-[1236px] max-h-[592px] mt-[22px] mb-[73px] mx-[102px]">
       <thead>
@@ -24,7 +31,8 @@ export function NotificationTableList({ data }: { data: NotificationList[] }) {
         ) : (
           data.map((Notification) => (
             <tr
-              key={Notification.id}
+              key={Notification.notification_id}
+              onClick={() => handleNoticeRowClick(Notification.link_url)}
               className="h-[65px] py-[10px] border-b-[1px]  border-[var(--color-white-stroke)] bg-[var(--color-white)] cursor-pointer">
               <td className="w-[72px] h-[65px] flex justify-center items-center pt-[10px]">
                 <img src={alarm} alt="알림" className="w-[22px] h-[26px]" />
@@ -33,7 +41,7 @@ export function NotificationTableList({ data }: { data: NotificationList[] }) {
                 <p className="h-[25px]">{Notification.content}</p>
               </td>
               <td className="w-[263px] h-[65px] text-center font-medium text-[20px] text-[var(--color-text-on-white)] py-[20px]">
-                {Notification.create_at}
+                {Notification.created_at}
               </td>
             </tr>
           ))
@@ -101,10 +109,10 @@ export function MobileNotification({ data }: { data: NotificationList[] }) {
       ) : (
         data.map((Notification) => (
           <div
-            key={Notification.id}
+            key={Notification.notification_id}
             className="h-[56px] border-b-[1px] border-[var(--color-white-stroke)] bg-[var(--color-white)] cursor-pointer">
             <div className="ml-[12px] mt-[12px]">
-              <p className="text-[8px] text-text-on-background font-normal">{Notification.create_at}</p>
+              <p className="text-[8px] text-text-on-background font-normal">{Notification.created_at}</p>
             </div>
             <div className="flex justify-center">
               <div className="w-full max-w-[256px] h-[16px] flex justify-start items-center mt-[6px]">


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #108 

### ✨️ 작업 내용

- 페이지별 완료 내용
마이페이지의 메시지 목록, 알림 목록(기본 페이지)에 API 연동 완료
마이페이지의 메시지 상세보기 페이지에 API 연동 완료

- 기능별 완료 내용 
메시지 목록의 읽음표시 API 연동 완료
메시지 목록의 삭제하기 API 연동 완료
알림 목록의 클릭시 URL 이동 API 연동 완료

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

현재 useEffect - axiosInstance 방식으로 구현해두었습니다. 
추후 useQuery 방식을 사용하도록 바꿀 계획입니다.

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.
<img width="823" height="580" alt="image" src="https://github.com/user-attachments/assets/85697976-798d-4851-82f9-d5b53289a875" />

<img width="653" height="566" alt="image" src="https://github.com/user-attachments/assets/69e0c89e-4fbb-42a8-be40-9d60b348e4cc" />

<img width="822" height="554" alt="image" src="https://github.com/user-attachments/assets/9116385c-892c-4139-aee0-3a10e057fb19" />
