### PR TITLE
[Feat] 관리자 페이지 라우팅 처리

### DIFF
--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -1,0 +1,31 @@
+import { useAuth } from '@/context/AuthContext';
+import ScrollToTop from '@utils/scrollToTop';
+import Navbar from '@components/Navbar';
+import { Suspense } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import TabBar from '@components/TabBar';
+
+const AdminLayout = () => {
+  const { user } = useAuth();
+
+  if (user.role !== 'ADMIN') {
+    return <Navigate to={'/'} replace />;
+  }
+  return (
+    <>
+      <ScrollToTop />
+      <Navbar />
+      <div className="bg-background lg:pb-0 max-lg:pb-[64px]" style={{ minHeight: 'calc(100vh - 75px)' }}>
+        <Suspense fallback={null}>
+          <Outlet />
+        </Suspense>
+      </div>
+
+      <div className="lg:hidden max-lg:block">
+        <TabBar />
+      </div>
+    </>
+  );
+};
+
+export default AdminLayout;

--- a/src/pages/AdminPage/AdiminComplaintPage.tsx
+++ b/src/pages/AdminPage/AdiminComplaintPage.tsx
@@ -1,0 +1,4 @@
+const AdminComplaintPage = () => {
+  return <div>Complaint Page</div>;
+};
+export default AdminComplaintPage;

--- a/src/pages/AdminPage/ComplaintPage.tsx
+++ b/src/pages/AdminPage/ComplaintPage.tsx
@@ -1,0 +1,4 @@
+const ComplaintPage = () => {
+  return <div>Complaint Page</div>;
+};
+export default ComplaintPage;

--- a/src/pages/AdminPage/ComplaintPage.tsx
+++ b/src/pages/AdminPage/ComplaintPage.tsx
@@ -1,4 +1,0 @@
-const ComplaintPage = () => {
-  return <div>Complaint Page</div>;
-};
-export default ComplaintPage;

--- a/src/routes/pageRoutes.tsx
+++ b/src/routes/pageRoutes.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, type RouteObject } from 'react-router-dom';
 import { lazyRoutes } from './routes';
 import HomeLayout from '@/layouts/HomeLayout';
 import ProtectedLayout from '@/layouts/ProtectedLayout';
+import AdminLayout from '@/layouts/AdminLayout';
 import TestPage from '@/pages/TestPage';
 
 export const publicRoutes: RouteObject[] = [
@@ -48,4 +49,14 @@ export const protectedRoutes: RouteObject[] = [
   },
 ];
 
-export const router = createBrowserRouter([...publicRoutes, ...protectedRoutes]);
+export const adminRoutes: RouteObject[] = [
+  {
+    path: '/admin',
+    element: <AdminLayout />,
+    children: [
+      //ex: { path: 'report', element: <lazyRoutes.AdminReportPage /> },
+    ],
+  },
+];
+
+export const router = createBrowserRouter([...publicRoutes, ...protectedRoutes, ...adminRoutes]);

--- a/src/routes/pageRoutes.tsx
+++ b/src/routes/pageRoutes.tsx
@@ -55,6 +55,7 @@ export const adminRoutes: RouteObject[] = [
     element: <AdminLayout />,
     children: [
       //ex: { path: 'report', element: <lazyRoutes.AdminReportPage /> },
+      { path: 'complaint', element: <lazyRoutes.AdminComplaintPage /> },
     ],
   },
 ];

--- a/src/routes/routes.tsx
+++ b/src/routes/routes.tsx
@@ -19,4 +19,5 @@ export const lazyRoutes = {
   PromptGuidePage: React.lazy(() => import('../pages/PromptGuidePage/PromptGuidePage')),
   PromptGuideDetailPage: React.lazy(() => import('../pages/PromptGuidePage/PromptGuideDetailPage')),
   PromptEditPage: React.lazy(() => import('../pages/PromptEdit/PromptEditPage')),
+  AdminComplaintPage: React.lazy(() => import('../pages/AdminPage/AdiminComplaintPage')),
 };


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #230 

### ✨️ 작업 내용

관리자 페이지 라우팅 처리

### 💭 코멘트

관리자 페이지 layout파일은 메인페이지 리턴 조건문(관리자 아닐 경우 메인페이지로 이동)을 빼고는 ProtectedLayout.tsx파일과 동일하게 구성하였습니다. 기존 protectedroutes에 url경로 추가하신 것처럼 똑같이 사용하시면 될 것 같습니다!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.