### PR TITLE
Refactor: 어드민 페이지 접근 조건 수정

### DIFF
--- a/src/layouts/AdminLayout.tsx
+++ b/src/layouts/AdminLayout.tsx
@@ -8,7 +8,7 @@ import TabBar from '@components/TabBar';
 const AdminLayout = () => {
   const { user } = useAuth();
 
-  if (user.role !== 'USER') {
+  if (user.role !== 'ADMIN') {
     return <Navigate to={'/'} replace />;
   }
   return (


### PR DESCRIPTION
user role이 ADMIN이 아닌경우 메인페이지로 옮겨가도록 수정(#234)

<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #234 

### ✨️ 작업 내용

작업중에 사용자 role이 user일때도 관리자 페이지 접근이 가능하도록 임시로 수정했었는데  develop 브랜치에는 원래대로 관리자만 어드민 페이지에 접근가능하여야 하므로 이 부분 수정하였습니다. 현재는 role 이 ADMIN인 경우에만 접근 가능한 상태입니다

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.