### PR TITLE
[Design] 버튼 width 값 고정

### DIFF
--- a/src/components/Button/PrimaryButton.tsx
+++ b/src/components/Button/PrimaryButton.tsx
@@ -98,7 +98,15 @@ const PrimaryButton = ({
         primaryButtonTheme.buttonType[buttonType],
       )}
       style={
-        buttonType === 'square' ? { paddingTop: py, paddingBottom: py, paddingLeft: px, paddingRight: px } : undefined
+        buttonType === 'square' && py !== undefined
+          ? {
+              paddingTop: py,
+              paddingBottom: py,
+              paddingLeft: px,
+              paddingRight: px,
+              width: `${text !== '테스트 결과' ? '99px' : '100%'}`,
+            }
+          : undefined
       }>
       {text}
     </button>


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #243 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

- 버튼 width `99px`로 고정
- **이미지 업로드(active, non-active), 인증번호 발송, 인증확인, 재발송, 시간 나오는 버튼, 인증 완료** 등에서만 고정되도록 

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

|`PrimaryButton.tsx`|
|--|
| <img width="352" height="307" alt="스크린샷 2025-10-17 오후 5 07 38" src="https://github.com/user-attachments/assets/534d4a54-dbea-45b5-b17c-bce3d62ee563" /> |
