### PR TITLE
[Design] 모바일 버전 프롬프트 글 넘침 현상 수정

### DIFF
--- a/src/pages/HomePage/components/PromptMobileCard.tsx
+++ b/src/pages/HomePage/components/PromptMobileCard.tsx
@@ -16,7 +16,7 @@ const PromptMobileCard = ({ prompt }: PromptMobileCardProps) => {
         {prompt.images?.[0]?.image_url ? (
           <img src={prompt.images[0].image_url} alt="프롬프트 이미지" />
         ) : (
-          <p className="text-text-on-white text-[6px] font-light leading-[9.6px] tracking-[0.12px] absolute top-[8px] px-[10px] pb-[8px] line-clamp-9">
+          <p className="text-text-on-white text-[6px] font-light leading-[9.6px] tracking-[0.12px] absolute top-[8px] px-[10px] pb-[8px] line-clamp-9 w-full">
             {prompt.prompt_result}
           </p>
         )}


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #311 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

- `모바일 버전 프롬프트 카드` 컴포넌트 에서 글이 넘쳐 보이는 문제 수정

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

|수전 전|수정 후|
| -- | -- |
| <img width="480" height="125" alt="스크린샷 2025-11-17 오후 1 17 03" src="https://github.com/user-attachments/assets/da5da39b-dddf-44c3-b824-2845d7c361ac" /> | <img width="480" height="125" alt="스크린샷 2025-11-17 오후 1 17 15" src="https://github.com/user-attachments/assets/355dfc53-28e6-43d9-8238-ad2fcb5aeaf4" /> |

