### PR TITLE
[Design] 이미지 object-cover 추가

### DIFF
--- a/src/pages/HomePage/components/PromptMobileCard.tsx
+++ b/src/pages/HomePage/components/PromptMobileCard.tsx
@@ -14,7 +14,7 @@ const PromptMobileCard = ({ prompt }: PromptMobileCardProps) => {
     <div className="bg-white rounded-[8px] flex h-[109px] overflow-hidden">
       <div className="w-[109px] relative bg-secondary text-text-on-white text-[6px] font-light leading-[9.6px] tracking-[0.12px]">
         {prompt.images?.[0]?.image_url ? (
-          <img src={prompt.images[0].image_url} alt="프롬프트 이미지" />
+          <img src={prompt.images[0].image_url} alt="프롬프트 이미지" className="object-cover w-full h-full" />
         ) : (
           <p className="text-text-on-white text-[6px] font-light leading-[9.6px] tracking-[0.12px] absolute top-[8px] px-[10px] pb-[8px] line-clamp-9 w-full">
             {prompt.prompt_result}


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #311 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

- 이미지가 꽉 차게 보이도록 `object-cover` 추가함

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

|수정 전|수정 후|
| -- | -- |
| <img width="480" height="125" alt="스크린샷 2025-11-17 오후 1 23 22" src="https://github.com/user-attachments/assets/a2f96dde-f488-4db5-ae71-fc0d4e51ff6b" /> | <img width="480" height="125" alt="스크린샷 2025-11-17 오후 1 23 38" src="https://github.com/user-attachments/assets/d2fd0643-9ce5-44a5-84a6-80dadbc317f4" /> |
