### PR TITLE
[Fix] 로그인 여부, 결제 여부에 따른 결제 로직 수정

### DIFF
--- a/src/hooks/mutations/MainPage/usePostRequestPayment.ts
+++ b/src/hooks/mutations/MainPage/usePostRequestPayment.ts
@@ -46,6 +46,12 @@ export const usePayment = () => {
 
       return result;
     } catch (error: any) {
+      // 409: 이미 구매한 프롬프트 (즉시 다운로드 진행)
+      if (error.response?.status === 409) {
+        console.log('이미 구매한 프롬프트입니다. 다운로드를 진행합니다.');
+        return { success: true, message: '이미 구매한 프롬프트입니다.' };
+      }
+
       console.error('결제 처리 중 오류 발생:', error);
       throw error;
     }

--- a/src/hooks/queries/PromptDetailPage/usePayment.tsx
+++ b/src/hooks/queries/PromptDetailPage/usePayment.tsx
@@ -1,65 +1,65 @@
-import { useState } from 'react';
-import { useAuth } from '@/context/AuthContext';
-import usePostRequestPayment, { usePayment } from '@/hooks/mutations/MainPage/usePostRequestPayment';
+// import { useState } from 'react';
+// import { useAuth } from '@/context/AuthContext';
+// import { usePayment } from '@/hooks/mutations/MainPage/usePostRequestPayment';
 
-// 포트원 결제 요청 데이터 타입
-interface PortOnePaymentData {
-  pg: string;
-  pay_method: string;
-  merchant_uid: string;
-  name: string;
-  amount: number;
-  buyer_email: string;
-  buyer_name: string;
-  buyer_tel: string;
-  buyer_addr: string;
-  buyer_postcode: string;
-  m_redirect_url: string;
-  custom_data: {
-    promptId: number;
-  };
-}
+// // 포트원 결제 요청 데이터 타입
+// interface PortOnePaymentData {
+//   pg: string;
+//   pay_method: string;
+//   merchant_uid: string;
+//   name: string;
+//   amount: number;
+//   buyer_email: string;
+//   buyer_name: string;
+//   buyer_tel: string;
+//   buyer_addr: string;
+//   buyer_postcode: string;
+//   m_redirect_url: string;
+//   custom_data: {
+//     promptId: number;
+//   };
+// }
 
-// 포트원 결제 응답 타입
-interface PortOneResponse {
-  success: boolean;
-  imp_uid?: string;
-  merchant_uid?: string;
-  error_msg?: string;
-  paid_amount?: number;
-  pay_method?: string;
-}
+// // 포트원 결제 응답 타입
+// interface PortOneResponse {
+//   success: boolean;
+//   imp_uid?: string;
+//   merchant_uid?: string;
+//   error_msg?: string;
+//   paid_amount?: number;
+//   pay_method?: string;
+// }
 
-// 포트원 v1 타입 정의
-declare global {
-  interface Window {
-    IMP: {
-      init: (impCode: string) => void;
-      request_pay: (paymentData: PortOnePaymentData, callback: (response: PortOneResponse) => void) => void;
-    };
-  }
-}
+// // 포트원 v1 타입 정의
+// declare global {
+//   interface Window {
+//     IMP: {
+//       init: (impCode: string) => void;
+//       request_pay: (paymentData: PortOnePaymentData, callback: (response: PortOneResponse) => void) => void;
+//     };
+//   }
+// }
 
-const usePayment = () => {
-  const [loading, setLoading] = useState(false);
-  const { user } = useAuth();
-  const [phoneNumber, setPhoneNumber] = useState<string>('');
+// const usePayment = () => {
+//   const [loading, setLoading] = useState(false);
+//   const { user } = useAuth();
+//   const [phoneNumber, setPhoneNumber] = useState<string>('');
 
-  const { handlePayment } = usePayment();
+//   const { handlePayment } = usePayment();
 
-  if (!window.PortOne) return; // SDK 없으면 막기
-  setLoading(true);
-  try {
-    const result = await handlePayment(promptId);
-    console.log('결제 완료:', result);
-    _onPaid();
-    onClose();
-  } catch (err: any) {
-    console.error(err);
-    alert(err.message || '결제 실패');
-  } finally {
-    setLoading(false);
-  }
-};
+//   if (!window.PortOne) return; // SDK 없으면 막기
+//   setLoading(true);
+//   try {
+//     const result = await handlePayment(promptId);
+//     console.log('결제 완료:', result);
+//     _onPaid();
+//     onClose();
+//   } catch (err: any) {
+//     console.error(err);
+//     alert(err.message || '결제 실패');
+//   } finally {
+//     setLoading(false);
+//   }
+// };
 
-export default usePayment;
+// export default usePayment;

--- a/src/hooks/queries/PromptDetailPage/usePayment.tsx
+++ b/src/hooks/queries/PromptDetailPage/usePayment.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import usePostRequestPayment, { usePayment } from '@/hooks/mutations/MainPage/usePostRequestPayment';
+
+// 포트원 결제 요청 데이터 타입
+interface PortOnePaymentData {
+  pg: string;
+  pay_method: string;
+  merchant_uid: string;
+  name: string;
+  amount: number;
+  buyer_email: string;
+  buyer_name: string;
+  buyer_tel: string;
+  buyer_addr: string;
+  buyer_postcode: string;
+  m_redirect_url: string;
+  custom_data: {
+    promptId: number;
+  };
+}
+
+// 포트원 결제 응답 타입
+interface PortOneResponse {
+  success: boolean;
+  imp_uid?: string;
+  merchant_uid?: string;
+  error_msg?: string;
+  paid_amount?: number;
+  pay_method?: string;
+}
+
+// 포트원 v1 타입 정의
+declare global {
+  interface Window {
+    IMP: {
+      init: (impCode: string) => void;
+      request_pay: (paymentData: PortOnePaymentData, callback: (response: PortOneResponse) => void) => void;
+    };
+  }
+}
+
+const usePayment = () => {
+  const [loading, setLoading] = useState(false);
+  const { user } = useAuth();
+  const [phoneNumber, setPhoneNumber] = useState<string>('');
+
+  const { handlePayment } = usePayment();
+
+  if (!window.PortOne) return; // SDK 없으면 막기
+  setLoading(true);
+  try {
+    const result = await handlePayment(promptId);
+    console.log('결제 완료:', result);
+    _onPaid();
+    onClose();
+  } catch (err: any) {
+    console.error(err);
+    alert(err.message || '결제 실패');
+  } finally {
+    setLoading(false);
+  }
+};
+
+export default usePayment;

--- a/src/pages/PromptDetailPage/PromptDetailPage.tsx
+++ b/src/pages/PromptDetailPage/PromptDetailPage.tsx
@@ -9,7 +9,6 @@ import PromptAuthorAndReview from './components/PromptAuthorAndReview';
 import ReportModal from './components/ReportModal';
 import DownloadModal from './components/DownloadModal';
 import SocialLoginModal from '@/components/Modal/SocialLoginModal';
-import PaymentModal from './components/PaymentModal';
 
 // hooks
 import { useShowLoginModal } from '@/hooks/useShowLoginModal';
@@ -49,7 +48,6 @@ const PromptDetailPage = () => {
   const [isPaid, setIsPaid] = useState(false);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const [isDownloadModalOpen, setIsDownloadModalOpen] = useState(false);
-  const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [downloadData, setDownloadData] = useState<{ title: string; content: string } | null>(null);
 
   const { loginModalShow, setLoginModalShow, handleShowLoginModal } = useShowLoginModal();
@@ -89,10 +87,6 @@ const PromptDetailPage = () => {
   const { mutateAsync: fetchDownload } = usePromptDownload();
   const handleDownloadClick = async () => {
     if (!Number.isFinite(promptId)) return;
-    if (prompt && !prompt.is_free && !isPaid) {
-      setIsPaymentModalOpen(true);
-      return;
-    }
 
     try {
       const res = await fetchDownload(promptId);
@@ -107,17 +101,12 @@ const PromptDetailPage = () => {
           return;
         }
         if (status === 403) {
-          setIsPaymentModalOpen(true);
+          alert('결제가 필요한 프롬프트입니다. 먼저 결제를 진행해주세요.');
           return;
         }
       }
       alert('다운로드를 불러오지 못했습니다.');
     }
-  };
-
-  const handlePaid = () => {
-    setIsPaid(true);
-    setIsPaymentModalOpen(false);
   };
 
   const handleToggleFollow = async () => {
@@ -181,15 +170,6 @@ const PromptDetailPage = () => {
       </div>
 
       <ReportModal isOpen={isReportModalOpen} onClose={() => setIsReportModalOpen(false)} promptId={promptId} />
-      {isPaymentModalOpen && (
-        <PaymentModal
-          promptId={Number(id)}
-          title={prompt.title}
-          price={prompt.price}
-          onClose={() => setIsPaymentModalOpen(false)}
-          onPaid={handlePaid}
-        />
-      )}
       {downloadData && (
         <DownloadModal
           isOpen={isDownloadModalOpen}

--- a/src/pages/PromptDetailPage/components/PromptDetailCard.tsx
+++ b/src/pages/PromptDetailPage/components/PromptDetailCard.tsx
@@ -222,8 +222,6 @@ const PromptDetailCard = ({
     downloadPrompt(promptId);
   };
 
-  console.log(promptResult);
-
   const currentUrl = window.location.href;
 
   // Kakao SDK 초기화

--- a/src/pages/PromptDetailPage/components/PromptDetailCard.tsx
+++ b/src/pages/PromptDetailPage/components/PromptDetailCard.tsx
@@ -28,7 +28,7 @@ import XIcon from '@assets/icon-x-logo.svg';
 import KakaoIcon from '../assets/kakaotalk-logo.svg';
 import LinkIcon from '../assets/link-logo.svg';
 import FacebookIcon from '../assets/facebook-logo.svg';
-import PaymentModal from './PaymentModal';
+import usePayment from '@/hooks/mutations/MainPage/usePostRequestPayment';
 
 interface Props {
   title: string;
@@ -63,7 +63,7 @@ const PromptDetailCard = ({
   tags = [],
   description: descProp,
   usageGuide: usageProp,
-  isPaid = false,
+  isPaid,
   price,
   isFree,
   onDownload,
@@ -73,6 +73,8 @@ const PromptDetailCard = ({
   const { data, isLoading } = useGetPromptDetail(promptId, {
     enabled: Number.isFinite(promptId),
   });
+
+  const accessToken = localStorage.getItem('accessToken');
 
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
   const navigate = useNavigate();
@@ -220,6 +222,8 @@ const PromptDetailCard = ({
     downloadPrompt(promptId);
   };
 
+  console.log(promptResult);
+
   const currentUrl = window.location.href;
 
   // Kakao SDK 초기화
@@ -293,12 +297,22 @@ const PromptDetailCard = ({
       ? '※ 다운로드를 하고 실제 프롬프트를 사용해보세요!'
       : '※ 결제 후 ‘프롬프트 다운로드’를 누르면 확인하실 수 있습니다. 열람 후에는 환불이 불가합니다.';
 
-  const [isPaymentBlockedOpen, setIsPaymentBlockedOpen] = useState(false);
+  const { handlePayment } = usePayment();
 
-  const handlePrimaryAction = () => {
-    // 유료 + 구매 전 → 결제 모달(현재는 결제 제한 안내)
+  const handlePrimaryAction = async () => {
+    if (accessToken === null) {
+      // 로그인하지 않은 경우 로그인 모달 오픈
+      onDownload();
+      return;
+    }
+    // 유료 + 구매 전 → 결제 진행
     if (isPaidPrompt && !hasPurchased) {
-      setIsPaymentBlockedOpen(true);
+      try {
+        await handlePayment(promptId);
+        onDownload();
+      } catch (err: any) {
+        alert(err.message || '결제에 실패했습니다.');
+      }
       return;
     }
 
@@ -354,7 +368,7 @@ const PromptDetailCard = ({
                         type="button"
                         onClick={() => handleMainCategoryClick(cat)}
                         className="inline-flex items-center gap-1 text-[14px] text-[#030712]
-                         px-3 py-2 hover:bg-gray-100 transition cursor-pointer"
+                        px-3 py-2 hover:bg-gray-100 transition cursor-pointer"
                         aria-label={`메인 카테고리 ${displayName}로 이동`}>
                         {displayName}
                         <img src={arrowRightBlack} alt="" className="w-[16px] h-[16px]" />
@@ -599,19 +613,6 @@ const PromptDetailCard = ({
           onClickNo={() => setIsDeleteConfirmOpen(false)}
         />
       )}
-
-      {isPaymentBlockedOpen && 
-        <PaymentModal
-          promptId={promptId}
-          title={title}
-          price={price}
-          onClose={() => setIsPaymentBlockedOpen(false)}
-          onPaid={() => {
-            setIsPaymentBlockedOpen(false);
-            // You may want to trigger a refresh or update state here if needed
-          }}
-        />
-      }
     </>
   );
 };


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #255 

### ✨️ 작업 내용

미로그인 상태에서 프롬프트 결제 시도 시, 로그인 모달이 뜨도록 수정.
이미 결제한 프롬프트인 경우, 서버에서 409 에러 반환, 이를 활용해 구매 상태 판별

### 💭 코멘트

현재 프롬프트 디테일 카드 접근 시, 서버에서 isPaid를 받아오는 것이 아닌 결제 시도 시 결제 여부를 확인하는 구조입니다.
이후, 백엔드 응답 구조 수정 완료 후 리팩토링 예정입니다.

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.