### PR TITLE
[Fix] 이미지, 파일 전송 시 기본 문구 설정

### DIFF
--- a/src/pages/ChatPage/components/ChatListItem.tsx
+++ b/src/pages/ChatPage/components/ChatListItem.tsx
@@ -11,6 +11,10 @@ interface ChatListItemProps {
     content: string;
     sent_at: Date | string;
     has_attachments: boolean;
+    attachment_summary?: {
+      image_count: number;
+      file_count: number;
+    } | null;
   };
   unread_count: number;
   is_pinned: boolean;
@@ -20,6 +24,10 @@ interface ChatListItemProps {
 
 const ChatListItem = ({ partner, last_message, unread_count, is_clicked, onClick }: ChatListItemProps) => {
   const { month, day } = formatDate(last_message.sent_at);
+  console.log(last_message?.attachment_summary);
+
+  const attachmentMsg =
+    (last_message.attachment_summary?.image_count ?? 0) > 0 ? '사진을 보냈습니다.' : '파일을 보냈습니다.';
 
   return (
     <div
@@ -43,7 +51,7 @@ const ChatListItem = ({ partner, last_message, unread_count, is_clicked, onClick
         </div>
 
         <div className="flex items-center justify-between">
-          <p className="custom-body3 text-gray700 truncate">{last_message.content}</p>
+          <p className="custom-body3 text-gray700 truncate">{last_message.content || attachmentMsg}</p>
 
           {unread_count > 0 && (
             <button className="rounded-[200px] py-[2px] px-[6px] h-[19px] bg-alert custom-button3 text-white text-center">

--- a/src/types/ChatPage/chat.ts
+++ b/src/types/ChatPage/chat.ts
@@ -45,6 +45,10 @@ export type Room = {
     content: string;
     sent_at: string;
     has_attachments: boolean;
+    attachment_summary?: {
+      image_count: number;
+      file_count: number;
+    } | null;
   };
   unread_count: number;
   is_pinned: boolean;


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #406 

### ✨️ 작업 내용

작업 내용을 간략히 설명해주세요.

- 이미지, 파일 전송 시 채팅 리스트에서 보이는 기본 문구 설정
  - 이미지만 전송 시 : ‘사진을 보냈습니다’
  - 파일만 전송 시 : ‘파일을 보냈습니다’
  - 텍스트+이미지, 텍스트+파일 시 : 기존대로 텍스트 보이도록 처리

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

<img width="1710" height="857" alt="스크린샷 2026-06-07 오후 12 22 45" src="https://github.com/user-attachments/assets/cb41959c-04dd-49bb-9708-e7daaf8d6411" />
