### PR TITLE
[Feat] 관리자 화면 헤더

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -158,6 +158,17 @@ const Navbar = () => {
             <div className="flex justify-center items-center gap-[24px]">
               <PrimaryButton
                 buttonType="admin"
+                text="관리보드"
+                onClick={() => {
+                  navigate('/admin/dashboard');
+                }}
+                py={8}
+                px={39}
+                borderRadius={8}
+              />
+
+              <PrimaryButton
+                buttonType="admin"
                 text="신고함"
                 onClick={() => {
                   navigate('/admin/complaint');

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -35,7 +35,7 @@ const Navbar = () => {
 
   const navigate = useNavigate();
 
-  const { accessToken, user } = useAuth();
+  const { accessToken, user, logout } = useAuth();
   const isAdmin = user.role === 'ADMIN';
   const { data } = useGetMember({ member_id: user.user_id });
   const { data: notificationData } = useGetNewNotification();
@@ -178,14 +178,7 @@ const Navbar = () => {
                 borderRadius={8}
               />
 
-              <PrimaryButton
-                buttonType="admin"
-                text="접근 상태 : 운영자"
-                onClick={() => {}}
-                py={8}
-                px={10}
-                borderRadius={32}
-              />
+              <PrimaryButton buttonType="admin" text="로그아웃" onClick={logout} py={8} px={39} borderRadius={32} />
 
               <img
                 src={AdminIcon}


### PR DESCRIPTION
<!-- 다음과 같이 제목 형식 통일 부탁합니다! -->
<!-- [태그] 작업 요약 -->

### 📑 이슈 번호

- close #421 

### ✨️ 작업 내용

- 관리자 화면 전용 헤더 UI 적용
- 대시보드 화면으로 이동하는 네비게이션 기능 구현
- 관리자 계정 로그아웃 기능 추가

### 💭 코멘트

코드 리뷰가 필요한 부분이나 궁금한 점을 자유롭게 남겨주세요!

### 📸 구현 결과

구현한 기능이 모두 결과물에 포함되도록 자유롭게 첨부해주세요.

https://github.com/user-attachments/assets/98949562-0443-4318-beb6-d64b63c99063

